### PR TITLE
Remove factory method for component instantiation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,121 @@
-# Duct
+# Duct UI
 
 ![NPM Version](https://img.shields.io/npm/v/%40duct-ui%2Fcore)
 
-A dom-first, compact user interface library aspiring to have a feature rich set of standard components bundled.
+A DOM-first UI framework with JSX templates, standard component library and explicit lifecycle management.
 
 > **⚠️ Under Construction**: This library is currently in early development and may exhibit unexpected behavior. APIs are subject to change and components may not be fully stable. Use with caution in production environments.
 
-## Abstract
+## Quick Start
 
-Duct: A new UI framework library that wraps over jsx templates and simplifies building
-UI components.
+```bash
+npm install @duct-ui/core @duct-ui/components
+```
 
-## Guiding Aphorisms
+```typescript
+import { createRef } from '@duct-ui/core'
+import Button from '@duct-ui/components/button/button'
 
-1. Don't hide the DOM
-2. Little magic, lots of logic
-3. Easy Packaging, Simple Reuse
+const buttonRef = createRef<ButtonLogic>()
 
-## Goals
+function MyApp() {
+  return (
+    <Button
+      ref={buttonRef}
+      label="Click me"
+      class="btn btn-primary"
+      on:click={() => console.log('Clicked!')}
+    />
+  )
+}
+```
 
-* Minimum friction in creating component libraries, distributing and using them
-* Ease of use in creating component libraries as part of a pnpm or yarn workspace and using them across applications in the workspace
-* Ease of embedding components in other components.
-* Clear separation of view code and logic code (as an antithesis to React)
-* Simplicity and no leaky abstractions
-* Templates are precompiled for speed
+## Core Concepts
 
-## Overall Project structure
+### Component Logic Access
+Access component methods via refs:
 
-* @duct-ui/core: The shared "Duct" runtime
-* @duct-ui/components: Core component library bundled with duct
-* @duct-ui/demo: Demo project to test / showcase core components
+```typescript
+const buttonRef = createRef<ButtonLogic>()
+
+// In render
+<Button ref={buttonRef} label="Toggle" />
+
+// Access methods
+buttonRef.current?.setDisabled(true)
+```
+
+### Lifecycle Phases
+Components follow explicit lifecycle phases:
+1. **Render**: JSX structure creation
+2. **Load**: Async data loading (optional)
+3. **Bind**: Event listeners and logic setup
+4. **Release**: Cleanup when component unmounts
+
+## Building Components
+
+```typescript
+import { createBlueprint, type BaseProps, type BaseComponentEvents } from '@duct-ui/core'
+
+interface MyComponentProps {
+  label: string
+  disabled?: boolean
+  'on:click'?: (el: HTMLElement) => void
+}
+
+interface MyComponentEvents extends BaseComponentEvents {
+  click: (el: HTMLElement) => void
+}
+
+interface MyComponentLogic {
+  setDisabled: (disabled: boolean) => void
+}
+
+function render(props: BaseProps<MyComponentProps>) {
+  const { disabled = false, label, ...moreProps} = props;
+  return (
+    <button
+      class="btn"
+      disabled={disabled}
+      {...moreProps}
+    >
+      {label}
+    </button>
+  )
+}
+
+function bind(el: HTMLElement, eventEmitter, props): BindReturn<MyComponentLogic> {
+  const button = el as HTMLButtonElement
+
+  function handleClick() {
+    eventEmitter.emit('click', button)
+  }
+
+  button.addEventListener('click', handleClick)
+
+  return {
+    setDisabled: (disabled) => button.disabled = disabled,
+    release: () => button.removeEventListener('click', handleClick)
+  }
+}
+
+const MyComponent = createBlueprint<MyComponentProps, MyComponentEvents, MyComponentLogic>(
+  { id: 'my-app/my-component' },
+  render,
+  { bind }
+)
+
+export default MyComponent
+```
+
+## Packages
+
+- **@duct-ui/core**: Core framework runtime and utilities
+- **@duct-ui/components**: Pre-built component library
+- **@duct-ui/demo**: Interactive demos and documentation
+
+## Philosophy
+
+1. **Don't hide the DOM** - Direct DOM access and manipulation
+2. **Little magic, lots of logic** - Explicit over implicit
+3. **Easy packaging, simple reuse** - Component composition and distribution

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -2,13 +2,112 @@
 
 ![NPM Version](https://img.shields.io/npm/v/%40duct-ui%2Fcomponents)
 
-The Duct component library offers a battery pack consisting of standard library of components which can either be used as is, composed or simply copied and modified to create derived components.
-
-Some of the components in the library offer styles for tailwind. You can import them in your
-`main.css` file using the `@source @duct-ui/components/path/to/css;` directive.
-
-See [the repository overview](https://github.com/navilan/duct-ui) for more insight into the whys and hows of Duct.
-
-The [Duct Website](https://duct-ui.org) offers comprehensive set of demos to understand its capabilities, workings and the built-in suite of components.
+A comprehensive component library for Duct UI with buttons, forms, navigation, layout, and data display components.
 
 > **⚠️ Under Construction**: This library is currently in early development and may exhibit unexpected behavior. APIs are subject to change and components may not be fully stable. Use with caution in production environments.
+
+## Installation
+
+```bash
+npm install @duct-ui/components @duct-ui/core
+```
+
+## Usage
+
+```typescript
+import { createRef } from '@duct-ui/core'
+import Button from '@duct-ui/components/button/button'
+import Toggle from '@duct-ui/components/button/toggle'
+import Modal from '@duct-ui/components/layout/modal'
+
+const buttonRef = createRef<ButtonLogic>()
+const modalRef = createRef<ModalLogic>()
+
+function MyApp() {
+  return (
+    <div>
+      <Button
+        ref={buttonRef}
+        label="Open Modal"
+        class="btn btn-primary"
+        on:click={() => modalRef.current?.show()}
+      />
+
+      <Toggle
+        onLabel="Hide"
+        offLabel="Show"
+        initialState="off"
+        on:change={(el, state) => console.log('Toggle:', state)}
+      />
+
+      <Modal
+        ref={modalRef}
+        content={() => <div>Modal content here</div>}
+        on:close={() => console.log('Modal closed')}
+      />
+    </div>
+  )
+}
+```
+
+## Available Components
+
+### Buttons
+- `Button` - Basic button with customizable styling
+- `IconButton` - Button with icon support
+- `Toggle` - Toggle button with on/off states
+- `AsyncToggle` - Toggle with async operations
+
+### Forms & Input
+- `EditableInput` - Click-to-edit text input
+
+### Dropdown & Navigation
+- `Menu` - Dropdown menu with items
+- `MenuItem` - Individual menu item
+- `MenuSeparator` - Visual separator for menus
+- `Select` - Dropdown selection component
+
+### Layout
+- `Modal` - Modal dialogs with positioning
+- `Tabs` - Tabbed interface component
+- `Drawer` - Responsive drawer/sidebar
+- `SidebarNav` - Navigation sidebar
+
+### Data Display
+- `List` - Paginated list component
+- `TreeView` - Hierarchical tree view
+
+### Images
+- `Icon` - Icon component with SVG support
+
+## Styling
+
+Components use Tailwind CSS classes. Some components include additional CSS files that should be imported:
+
+```css
+/* In your main CSS file */
+@import '@duct-ui/components/layout/drawer.css';
+@import '@duct-ui/components/layout/modal.css';
+@import '@duct-ui/components/data-display/tree-view.css';
+@import '@duct-ui/components/layout/sidebar-nav.css';
+```
+
+## Component Logic Access
+
+All components expose their logic through refs:
+
+```typescript
+const componentRef = createRef<ComponentLogic>()
+
+// Use in JSX
+<Component ref={componentRef} />
+
+// Access methods
+componentRef.current?.someMethod()
+```
+
+## Resources
+
+- [Main Repository](https://github.com/navilan/duct-ui)
+- [Core Framework](@duct-ui/core)
+- [Live Demos](https://duct-ui.org)

--- a/packages/components/src/button/async-toggle.tsx
+++ b/packages/components/src/button/async-toggle.tsx
@@ -229,10 +229,10 @@ function bind(
 
 const id = { id: 'duct/async-toggle' }
 
-export default () => {
-  return createBlueprint<AsyncToggleProps, AsyncToggleEvents, AsyncToggleLogic, AsyncToggleLoadData>(
-    id,
-    render,
-    { bind, load }
-  )
-}
+const AsyncToggle = createBlueprint<AsyncToggleProps, AsyncToggleEvents, AsyncToggleLogic, AsyncToggleLoadData>(
+  id,
+  render,
+  { bind, load }
+)
+
+export default AsyncToggle

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -20,12 +20,12 @@ function render(props: BaseProps<ButtonProps>) {
 
 const id = { id: "duct/button" }
 
-export default () => {
-  return createBlueprint<ButtonProps, ButtonEvents>(
-    id,
-    render,
-    {
-      domEvents: ['click', 'dblclick']
-    }
-  )
-}
+const Button = createBlueprint<ButtonProps, ButtonEvents>(
+  id,
+  render,
+  {
+    domEvents: ['click', 'dblclick']
+  }
+)
+
+export default Button

--- a/packages/components/src/button/icon-button.tsx
+++ b/packages/components/src/button/icon-button.tsx
@@ -1,6 +1,6 @@
 import { type BaseProps, createBlueprint } from "@duct-ui/core/blueprint"
 import { ButtonEvents, ButtonProps } from "./button"
-import makeIcon, { type IconSource, type IconSize } from "../images/icon"
+import Icon, { type IconSource, type IconSize } from "../images/icon"
 
 export type IconPosition = "start" | "end"
 
@@ -12,8 +12,7 @@ export type IconButtonProps = Partial<ButtonProps> & {
 }
 
 function renderIcon(icon: IconSource, size?: IconSize, iconClass?: string): JSX.Element {
-  const IconComponent = makeIcon()
-  return <IconComponent icon={icon} size={size || "sm"} class={iconClass} />
+  return <Icon icon={icon} size={size || "sm"} class={iconClass} />
 }
 
 function render(props: BaseProps<IconButtonProps>) {
@@ -42,11 +41,12 @@ function render(props: BaseProps<IconButtonProps>) {
 const id = { id: "duct/icon-button" }
 
 // Create the final component
-export default () => {
-  return createBlueprint<IconButtonProps, ButtonEvents>(
-    id,
-    render,
-    {
-      domEvents: ['click', 'dblclick'], // Automatically bind these DOM events
-    })
-}
+const IconButton = createBlueprint<IconButtonProps, ButtonEvents>(
+  id,
+  render,
+  {
+    domEvents: ['click', 'dblclick'], // Automatically bind these DOM events
+  }
+)
+
+export default IconButton

--- a/packages/components/src/button/toggle.tsx
+++ b/packages/components/src/button/toggle.tsx
@@ -115,12 +115,12 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<ToggleEvents>, props: 
 
 const id = { id: "duct/toggle" }
 
-export default () => {
-  return createBlueprint<ToggleProps, ToggleEvents, ToggleLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const Toggle = createBlueprint<ToggleProps, ToggleEvents, ToggleLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default Toggle

--- a/packages/components/src/data-display/tree-view.tsx
+++ b/packages/components/src/data-display/tree-view.tsx
@@ -331,13 +331,13 @@ function bind<T>(el: HTMLElement, eventEmitter: EventEmitter<TreeViewEvents>): B
 
 const id = { id: "duct/tree-view" }
 
-export default () => {
-  return createBlueprint<TreeViewProps, TreeViewEvents, TreeViewLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click'],
-      bind
-    }
-  )
-}
+const TreeView = createBlueprint<TreeViewProps, TreeViewEvents, TreeViewLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click'],
+    bind
+  }
+)
+
+export default TreeView

--- a/packages/components/src/dropdown/menu-item.tsx
+++ b/packages/components/src/dropdown/menu-item.tsx
@@ -1,6 +1,6 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
-import makeIcon, { type IconSource } from "../images/icon"
+import Icon, { type IconSource } from "../images/icon"
 
 export interface MenuItemEvents extends BaseComponentEvents {
   click: (el: HTMLElement, event: MouseEvent) => void
@@ -25,8 +25,7 @@ export type MenuItemProps = {
 } & Record<string, any>
 
 function renderIcon(icon: MenuItemIcon): JSX.Element {
-  const IconComponent = makeIcon()
-  return <IconComponent icon={icon} size="sm" class="mr-2" />
+  return <Icon icon={icon} size="sm" class="mr-2" />
 }
 
 function render(props: BaseProps<MenuItemProps>) {
@@ -129,13 +128,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<MenuItemEvents>): Bind
 
 const id = { id: "duct/menu-item" }
 
-export default () => {
-  return createBlueprint<MenuItemProps, MenuItemEvents, MenuItemLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click'],
-      bind
-    },
-  )
-}
+const MenuItem = createBlueprint<MenuItemProps, MenuItemEvents, MenuItemLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click'],
+    bind
+  },
+)
+
+export default MenuItem

--- a/packages/components/src/dropdown/menu-separator.tsx
+++ b/packages/components/src/dropdown/menu-separator.tsx
@@ -36,13 +36,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<MenuSeparatorEvents>):
 
 const id = { id: "duct/menu-separator" }
 
-export default () => {
-  return createBlueprint<MenuSeparatorProps, MenuSeparatorEvents, MenuSeparatorLogic>(
-    id,
-    render,
-    {
-      domEvents: [],
-      bind
-    },
-  )
-}
+const MenuSeparator = createBlueprint<MenuSeparatorProps, MenuSeparatorEvents, MenuSeparatorLogic>(
+  id,
+  render,
+  {
+    domEvents: [],
+    bind
+  },
+)
+
+export default MenuSeparator

--- a/packages/components/src/dropdown/menu.tsx
+++ b/packages/components/src/dropdown/menu.tsx
@@ -179,13 +179,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<MenuEvents>): BindRetu
 
 const id = { id: "duct/menu" }
 
-export default () => {
-  return createBlueprint<MenuProps, MenuEvents, MenuLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click'],
-      bind
-    },
-  )
-}
+const Menu = createBlueprint<MenuProps, MenuEvents, MenuLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click'],
+    bind
+  },
+)
+
+export default Menu

--- a/packages/components/src/dropdown/select.tsx
+++ b/packages/components/src/dropdown/select.tsx
@@ -1,6 +1,6 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
-import makeIcon, { IconSize, type IconSource } from "../images/icon"
+import Icon, { IconSize, type IconSource } from "../images/icon"
 
 export type SelectPlacement = 'bottom-start' | 'bottom-end' | 'top-start' | 'top-end' | 'bottom' | 'top'
 
@@ -53,8 +53,7 @@ export type SelectProps = {
 } & Record<string, any>
 
 function renderIcon(icon: SelectItemIcon, iconSize: IconSize = 'sm', iconClass: string = ""): JSX.Element {
-  const IconComponent = makeIcon()
-  return <IconComponent icon={icon} size={iconSize} class={iconClass} />
+  return <Icon icon={icon} size={iconSize} class={iconClass} />
 }
 
 function render(props: BaseProps<SelectProps>) {
@@ -344,13 +343,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<SelectEvents>): BindRe
 
 const id = { id: "duct/select" }
 
-export default () => {
-  return createBlueprint<SelectProps, SelectEvents, SelectLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click'],
-      bind
-    },
-  )
-}
+const Select = createBlueprint<SelectProps, SelectEvents, SelectLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click'],
+    bind
+  },
+)
+
+export default Select

--- a/packages/components/src/images/icon.tsx
+++ b/packages/components/src/images/icon.tsx
@@ -75,11 +75,11 @@ function render(props: BaseProps<IconProps>) {
 
 const id = { id: "duct/icon" }
 
-export default () => {
-  return createBlueprint<IconProps, IconEvents, IconLogic>(
-    id,
-    render,
-    {
-    },
-  )
-}
+const Icon = createBlueprint<IconProps, IconEvents, IconLogic>(
+  id,
+  render,
+  {
+  },
+)
+
+export default Icon

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,27 +1,27 @@
 // Button Components
-export { default as makeButton } from "./button/button"
-export { default as makeIconButton } from "./button/icon-button"
-export { default as makeToggle } from "./button/toggle"
-export { default as makeAsyncToggle } from "./button/async-toggle"
+export { default as Button } from "./button/button"
+export { default as IconButton } from "./button/icon-button"
+export { default as Toggle } from "./button/toggle"
+export { default as AsyncToggle } from "./button/async-toggle"
 
 // Input Components
-export { default as makeEditable } from "./input/editable"
+export { default as Editable } from "./input/editable"
 
 // Dropdown Components
-export { default as makeMenu } from "./dropdown/menu"
-export { default as makeMenuItem } from "./dropdown/menu-item"
-export { default as makeMenuSeparator } from "./dropdown/menu-separator"
-export { default as makeSelect } from "./dropdown/select"
+export { default as Menu } from "./dropdown/menu"
+export { default as MenuItem } from "./dropdown/menu-item"
+export { default as MenuSeparator } from "./dropdown/menu-separator"
+export { default as Select } from "./dropdown/select"
 
 // Data Display Components
-export { default as makeList } from "./data-display/list"
-export { default as makeTreeView } from "./data-display/tree-view"
+export { default as List } from "./data-display/list"
+export { default as TreeView } from "./data-display/tree-view"
 
 // Layout Components
-export { default as makeDrawer } from "./layout/drawer"
-export { default as makeModal } from "./layout/modal"
-export { default as makeSidebarNav } from "./layout/sidebar-nav"
-export { default as makeTabs } from "./layout/tabs"
+export { default as Drawer } from "./layout/drawer"
+export { default as Modal } from "./layout/modal"
+export { default as SidebarNav } from "./layout/sidebar-nav"
+export { default as Tabs } from "./layout/tabs"
 
 // Image Components
-export { default as makeIcon } from "./images/icon"
+export { default as Icon } from "./images/icon"

--- a/packages/components/src/input/editable.tsx
+++ b/packages/components/src/input/editable.tsx
@@ -226,13 +226,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<InputEvents>): BindRet
 
 const id = { id: "duct/editable-input" }
 
-export default () => {
-  return createBlueprint<InputProps, InputEvents, InputLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click', 'dblclick'],
-      bind
-    },
-  )
-}
+const Editable = createBlueprint<InputProps, InputEvents, InputLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click', 'dblclick'],
+    bind
+  },
+)
+
+export default Editable

--- a/packages/components/src/layout/drawer.tsx
+++ b/packages/components/src/layout/drawer.tsx
@@ -157,13 +157,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<DrawerEvents>): BindRe
 
 const id = { id: "duct/drawer" }
 
-export default () => {
-  return createBlueprint<DrawerProps, DrawerEvents, DrawerLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click'],
-      bind
-    },
-  )
-}
+const Drawer = createBlueprint<DrawerProps, DrawerEvents, DrawerLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click'],
+    bind
+  },
+)
+
+export default Drawer

--- a/packages/components/src/layout/modal.tsx
+++ b/packages/components/src/layout/modal.tsx
@@ -152,12 +152,12 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<ModalEvents>, props: a
 
 const id = { id: "duct/modal" }
 
-export default () => {
-  return createBlueprint<ModalProps, ModalEvents, ModalLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const Modal = createBlueprint<ModalProps, ModalEvents, ModalLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default Modal

--- a/packages/components/src/layout/sidebar-nav.tsx
+++ b/packages/components/src/layout/sidebar-nav.tsx
@@ -109,7 +109,7 @@ function render(props: BaseProps<SidebarNavProps>) {
                   {section.items.map(navItem => (
                     <li data-key={navItem.id} class={`sidebar-nav-item ${itemClass}`.trim()}>
                       <a
-                        href={navItem.href || `#${navItem.id}`}
+                        href={navItem.href || `/${navItem.id}`}
                         class={`sidebar-nav-item-link ${currentItem === navItem.id ? 'active' : ''} ${itemLinkClass}`.trim()}
                         data-nav-item-id={navItem.id}
                       >
@@ -158,13 +158,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<SidebarNavEvents>): Bi
 
 const id = { id: "duct/sidebar-nav" }
 
-export default () => {
-  return createBlueprint<SidebarNavProps, SidebarNavEvents, SidebarNavLogic>(
-    id,
-    render,
-    {
-      domEvents: ['click'],
-      bind
-    }
-  )
-}
+const SidebarNav = createBlueprint<SidebarNavProps, SidebarNavEvents, SidebarNavLogic>(
+  id,
+  render,
+  {
+    domEvents: ['click'],
+    bind
+  }
+)
+
+export default SidebarNav

--- a/packages/components/src/layout/tabs.tsx
+++ b/packages/components/src/layout/tabs.tsx
@@ -193,12 +193,12 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<TabsEvents>, props: an
 
 const id = { id: "duct/tabs" }
 
-export default () => {
-  return createBlueprint<TabsProps, TabsEvents, TabsLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const Tabs = createBlueprint<TabsProps, TabsEvents, TabsLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default Tabs

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,10 +2,78 @@
 
 ![NPM Version](https://img.shields.io/npm/v/%40duct-ui%2Fcore)
 
-The core library containing the component blueprint and minimal runtime for the Duct library.
-
-See [the repository overview](https://github.com/navilan/duct-ui) for more insight into the whys and hows of Duct.
-
-The [Duct Website](https://duct-ui.org) offers comprehensive set of demos to understand its capabilities and workings.
+The core runtime for Duct UI framework providing component blueprint, minimal runtime, and lifecycle management.
 
 > **⚠️ Under Construction**: This library is currently in early development and may exhibit unexpected behavior. APIs are subject to change and components may not be fully stable. Use with caution in production environments.
+
+## Installation
+
+```bash
+npm install @duct-ui/core
+```
+
+## Core APIs
+
+### `createBlueprint()`
+Creates a component blueprint with render, bind, and lifecycle functions:
+
+```typescript
+import { createBlueprint } from '@duct-ui/core'
+
+const MyComponent = createBlueprint<Props, Events, Logic>(
+  { id: 'my-app/component' },
+  render,
+  { bind, load } // load is optional
+)
+```
+
+### `createRef()`
+Creates a reference to access component logic:
+
+```typescript
+import { createRef } from '@duct-ui/core'
+
+const componentRef = createRef<ComponentLogic>()
+
+// In JSX
+<MyComponent ref={componentRef} />
+
+// Access methods
+componentRef.current?.someMethod()
+```
+
+### Component Lifecycle
+
+1. **Render Phase**: Component JSX is created and inserted into DOM
+2. **Load Phase** (optional): Async data loading before binding
+3. **Bind Phase**: Event listeners attached, logic initialized
+4. **Release Phase**: Cleanup when component is destroyed
+
+## Well-typed Components
+
+```typescript
+import type {
+  BaseProps,
+  BaseComponentEvents,
+  BindReturn
+} from '@duct-ui/core'
+
+interface MyComponentProps {
+  label: string
+  'on:click'?: (el: HTMLElement) => void
+}
+
+interface MyComponentEvents extends BaseComponentEvents {
+  click: (el: HTMLElement) => void
+}
+
+interface MyComponentLogic {
+  setLabel: (label: string) => void
+}
+```
+
+## Resources
+
+- [Main Repository](https://github.com/navilan/duct-ui)
+- [Component Library](@duct-ui/components)
+- [Live Demos](https://duct-ui.org)

--- a/packages/core/src/blueprint.ts
+++ b/packages/core/src/blueprint.ts
@@ -12,9 +12,6 @@ export interface BaseComponentEvents extends Record<string, any> {
   release: (el: HTMLElement) => void
 }
 
-interface ComponentEvents<Logic extends Record<string, any>> {
-  bound: (logic: Logic) => void
-}
 
 let instanceCounter = 0
 
@@ -123,128 +120,146 @@ export function createBlueprint<
   id: { id: string },
   render: (props: BaseProps<Props>) => JSX.Element,
   config: BlueprintConfig<Events, Logic, LoadData>
-): ((props: ComponentProps<Props>) => JSX.Element) & { getLogic: () => Promise<Logic> } {
+): (props: ComponentProps<Props>) => JSX.Element {
 
-  let componentObservable = new Observable<ComponentEvents<Logic>>()
+  // Store instance data for each rendered component
+  const instances = new Map<string, {
+    logic?: Logic
+    eventEmitter: EventEmitter<Events>
+    domEventHandlers: Map<string, EventListener>
+  }>()
 
-  let onBound = new Promise<Logic>(resolve => {
-    const emitter = (logic: Logic) => {
-      resolve(logic)
-      componentObservable.destroy()
-    }
-    componentObservable.on('bound', emitter)
-  })
-
-  const instanceId = `${id.id}--${instanceCounter++}`
-  let logic: Logic | undefined
-  let eventEmitter: EventEmitter<Events>
-  let domEventHandlers: Map<string, EventListener> = new Map()
-
-  // Create event emitter for this component instance
-  eventEmitter = {
-    emit<K extends keyof Events>(event: K, ...args: Parameters<Events[K]>) {
-      globalEventObservable.emit(event as string, [document.querySelector(`[data-duct-id="${instanceId}"]`), ...args])
-    },
-    on<K extends keyof Events>(event: K, callback: Events[K]) {
-      bindEventToInstance(instanceId, event as string, callback)
-    },
-    off<K extends keyof Events>(event: K, callback: Events[K]) {
-      // Find and remove the wrapped handler for this instance
-      const handlers = instanceHandlers.get(instanceId)
-      if (handlers) {
-        const wrappedHandler = handlers.get(event as string)
-        if (wrappedHandler) {
-          globalEventObservable.off(event as string, wrappedHandler)
-          handlers.delete(event as string)
+  // Helper to create event emitter for a specific instance
+  function createInstanceEventEmitter(instanceId: string): EventEmitter<Events> {
+    return {
+      emit<K extends keyof Events>(event: K, ...args: Parameters<Events[K]>) {
+        globalEventObservable.emit(event as string, [document.querySelector(`[data-duct-id="${instanceId}"]`), ...args])
+      },
+      on<K extends keyof Events>(event: K, callback: Events[K]) {
+        bindEventToInstance(instanceId, event as string, callback)
+      },
+      off<K extends keyof Events>(event: K, callback: Events[K]) {
+        // Find and remove the wrapped handler for this instance
+        const handlers = instanceHandlers.get(instanceId)
+        if (handlers) {
+          const wrappedHandler = handlers.get(event as string)
+          if (wrappedHandler) {
+            globalEventObservable.off(event as string, wrappedHandler)
+            handlers.delete(event as string)
+          }
         }
       }
     }
   }
 
-  observeLifecycle(instanceId, {
-    async onInsert(el) {
-      const htmlEl = el as HTMLElement
-
-      // Bind DOM event listeners if specified
-      if (config.domEvents) {
-        config.domEvents.forEach(eventName => {
-          const handler = (e: Event) => {
-            eventEmitter.emit(eventName as keyof Events, htmlEl, e)
-          }
-          htmlEl.addEventListener(eventName, handler)
-          domEventHandlers.set(eventName, handler)
-        })
-      }
-
-      // Call async load if provided
-      let loadData: LoadData | undefined
-      if (config.load) {
-        loadData = await config.load(htmlEl, getDuct()?.getProps(instanceId))
-      }
-
-      // Emit lifecycle events
-      eventEmitter.emit('bind' as keyof Events, htmlEl)
-
-      // Create component logic
-      if (config.bind) {
-        const customLogic = config.bind(htmlEl, eventEmitter, getDuct()?.getProps(instanceId), loadData)
-        // Merge default on/off with custom logic
-        logic = {
-          ...createDefaultLogic(eventEmitter),
-          ...customLogic
-        } as Logic
-      } else {
-        // Use default logic with on/off methods
-        // @ts-expect-error
-        logic = createDefaultLogic(eventEmitter) as Logic
-      }
-      getDuct().register(htmlEl, logic)
-
-      // Check if props contain a ref and set it
-      const props = getDuct()?.getProps(instanceId)
-      if (props?.ref && props.ref instanceof MutableRef) {
-        props.ref.current = logic
-      }
-
-      componentObservable.emit('bound', [logic])
-    },
-    onRemove(el) {
-      const htmlEl = el as HTMLElement
-
-      // Clean up DOM event listeners
-      domEventHandlers.forEach((handler, eventName) => {
-        htmlEl.removeEventListener(eventName, handler)
-      })
-      domEventHandlers.clear()
-
-      // Clean up all instance event handlers from global observable
-      unbindInstanceHandlers(instanceId)
-
-      // Clean up ref if it exists
-      const props = getDuct()?.getProps(instanceId)
-      if (props?.ref && props.ref instanceof MutableRef) {
-        props.ref.current = null
-        props.ref.destroy()
-      }
-
-      // Emit release event and cleanup
-      if (logic) {
-        eventEmitter.emit('release' as keyof Events, htmlEl)
-        if (logic.release) {
-          logic.release(htmlEl)
-        }
-        logic = undefined
-      }
-      getDuct()?.clearProps(instanceId)
-      // Clean up lifecycle handler to prevent memory leaks
-      cleanupLifecycleHandler(instanceId)
-    }
-  })
-
 
   const component = function (props: Props): JSX.Element {
+    // Generate unique instance ID during render
+    const instanceId = `${id.id}--${instanceCounter++}`
+
     // Extract and bind event props
     const { eventProps, regularProps } = extractEventProps(props)
+
+    // Create instance data if not exists
+    if (!instances.has(instanceId)) {
+      const eventEmitter = createInstanceEventEmitter(instanceId)
+
+      instances.set(instanceId, {
+        eventEmitter,
+        domEventHandlers: new Map()
+      })
+
+      // Register lifecycle callbacks for this specific instance
+      observeLifecycle(instanceId, {
+        async onInsert(el) {
+          const htmlEl = el as HTMLElement
+          const instance = instances.get(instanceId)!
+          const { eventEmitter, domEventHandlers } = instance
+
+          // Bind DOM event listeners if specified
+          if (config.domEvents) {
+            config.domEvents.forEach(eventName => {
+              const handler = (e: Event) => {
+                eventEmitter.emit(eventName as keyof Events, htmlEl, e)
+              }
+              htmlEl.addEventListener(eventName, handler)
+              domEventHandlers.set(eventName, handler)
+            })
+          }
+
+          // Call async load if provided
+          let loadData: LoadData | undefined
+          if (config.load) {
+            loadData = await config.load(htmlEl, getDuct()?.getProps(instanceId))
+          }
+
+          // Emit lifecycle events
+          eventEmitter.emit('bind' as keyof Events, htmlEl)
+
+          // Create component logic
+          let logic: Logic
+          if (config.bind) {
+            const customLogic = config.bind(htmlEl, eventEmitter, getDuct()?.getProps(instanceId), loadData)
+            // Merge default on/off with custom logic
+            logic = {
+              ...createDefaultLogic(eventEmitter),
+              ...customLogic
+            } as Logic
+          } else {
+            // Use default logic with on/off methods
+            // @ts-expect-error
+            logic = createDefaultLogic(eventEmitter) as Logic
+          }
+          instance.logic = logic
+          getDuct().register(htmlEl, logic)
+
+          // Check if props contain a ref and set it
+          const props = getDuct()?.getProps(instanceId)
+          if (props?.ref && props.ref instanceof MutableRef) {
+            props.ref.current = logic
+          }
+
+          // No longer emit 'bound' event - refs handle logic access now
+        },
+        onRemove(el) {
+          const htmlEl = el as HTMLElement
+          const instance = instances.get(instanceId)
+          if (!instance) return
+
+          const { eventEmitter, domEventHandlers, logic } = instance
+
+          // Clean up DOM event listeners
+          domEventHandlers.forEach((handler, eventName) => {
+            htmlEl.removeEventListener(eventName, handler)
+          })
+          domEventHandlers.clear()
+
+          // Clean up all instance event handlers from global observable
+          unbindInstanceHandlers(instanceId)
+
+          // Clean up ref if it exists
+          const props = getDuct()?.getProps(instanceId)
+          if (props?.ref && props.ref instanceof MutableRef) {
+            props.ref.current = null
+            props.ref.destroy()
+          }
+
+          // Emit release event and cleanup
+          if (logic) {
+            eventEmitter.emit('release' as keyof Events, htmlEl)
+            if (logic.release) {
+              logic.release(htmlEl)
+            }
+          }
+
+          // Clean up instance data
+          instances.delete(instanceId)
+          getDuct()?.clearProps(instanceId)
+          // Clean up lifecycle handler to prevent memory leaks
+          cleanupLifecycleHandler(instanceId)
+        }
+      })
+    }
 
     // Bind all on:* props to the instance
     Object.entries(eventProps).forEach(([eventName, handler]) => {
@@ -263,7 +278,5 @@ export function createBlueprint<
     return render(fullProps)
   }
 
-  return Object.assign(component, {
-    getLogic: () => onBound
-  }) as ((props: Props) => JSX.Element) & { getLogic: () => Promise<Logic> }
+  return component
 }

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -23,7 +23,7 @@ export class MutableRef<T = any> {
 
     // Only emit if value actually changed
     if (oldValue !== value) {
-      this.emit('set', [value])
+      this.emit('set', value)
     }
   }
 

--- a/packages/demo/src/components/DemoHeader.tsx
+++ b/packages/demo/src/components/DemoHeader.tsx
@@ -1,4 +1,4 @@
-import makeIconButton from "@duct-ui/components/button/icon-button"
+import IconButton from "@duct-ui/components/button/icon-button"
 
 export interface DemoHeaderProps {
   isMenuOpen?: boolean
@@ -7,7 +7,7 @@ export interface DemoHeaderProps {
   'on:menuToggle'?: (el: HTMLElement) => void
 }
 
-const IconButton = makeIconButton()
+// IconButton is now imported directly
 
 // Hamburger icon as string (3 horizontal lines)
 const hamburgerIcon = "☰"

--- a/packages/demo/src/components/DemoLayout.tsx
+++ b/packages/demo/src/components/DemoLayout.tsx
@@ -41,9 +41,9 @@ function render(props: DemoLayoutProps & { "data-duct-id": string }) {
               <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
               </svg>
-              <a 
+              <a
                 href={`${githubBaseUrl}${sourcePath}`}
-                target="_blank" 
+                target="_blank"
                 rel="noopener noreferrer"
                 class="text-primary hover:text-primary-focus underline"
               >
@@ -63,11 +63,11 @@ function render(props: DemoLayoutProps & { "data-duct-id": string }) {
 
 const id = { id: "duct-demo/demo-layout" }
 
-export default () => {
-  return createBlueprint<DemoLayoutProps, DemoLayoutEvents>(
-    id,
-    render,
-    {
-    }
-  )
-}
+const DemoLayout = createBlueprint<DemoLayoutProps, DemoLayoutEvents>(
+  id,
+  render,
+  {
+  }
+)
+
+export default DemoLayout

--- a/packages/demo/src/components/EmojiItem.tsx
+++ b/packages/demo/src/components/EmojiItem.tsx
@@ -92,12 +92,12 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<EmojiItemEvents>, prop
   function toggleFavorite(): void {
     const currentState = props.isFavorite ? props.isFavorite(emojiKeyAttr) : false
     const newState = !currentState
-    
+
     // Call parent's toggle function
     if (props.onToggleFavorite && emojiKeyAttr) {
       props.onToggleFavorite(emojiKeyAttr, newState)
     }
-    
+
     // Update UI immediately
     if (favoriteIcon) {
       favoriteIcon.textContent = newState ? '★' : '☆'
@@ -153,13 +153,13 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<EmojiItemEvents>, prop
 
 const id = { id: "duct-demo/emoji-item" }
 
-export default () => {
-  return createBlueprint<EmojiItemProps, EmojiItemEvents, EmojiItemLogic>(
-    id,
-    render,
-    {
-      domEvents: [],
-      bind
-    }
-  )
-}
+const EmojiItem = createBlueprint<EmojiItemProps, EmojiItemEvents, EmojiItemLogic>(
+  id,
+  render,
+  {
+    domEvents: [],
+    bind
+  }
+)
+
+export default EmojiItem

--- a/packages/demo/src/components/EventLog.tsx
+++ b/packages/demo/src/components/EventLog.tsx
@@ -114,12 +114,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<EventLogEvents>): Bin
 
 const id = { id: "duct-demo/event-log" }
 
-export default () => {
-  return createBlueprint<EventLogProps, EventLogEvents, EventLogLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const EventLog = createBlueprint<EventLogProps, EventLogEvents, EventLogLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default EventLog

--- a/packages/demo/src/components/Sidebar.tsx
+++ b/packages/demo/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
-import makeSidebarNav from "@duct-ui/components/layout/sidebar-nav"
+import SidebarNav from "@duct-ui/components/layout/sidebar-nav"
 import ductLogo from "../icons/duct-logo.svg"
 
 export interface SidebarEvents extends BaseComponentEvents {
@@ -29,7 +29,7 @@ export interface SidebarProps {
   'on:navigate'?: (el: HTMLElement, demoId: string) => void
 }
 
-const SidebarNav = makeSidebarNav()
+// SidebarNav is now imported directly
 
 function render(props: BaseProps<SidebarProps>) {
   const { categories, currentDemo, ...moreProps } = props
@@ -150,12 +150,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<SidebarEvents>): Bind
 
 const id = { id: "duct-demo/sidebar" }
 
-export default () => {
-  return createBlueprint<SidebarProps, SidebarEvents, SidebarLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const Sidebar = createBlueprint<SidebarProps, SidebarEvents, SidebarLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default Sidebar

--- a/packages/demo/src/demos/AsyncToggleDemo.tsx
+++ b/packages/demo/src/demos/AsyncToggleDemo.tsx
@@ -1,11 +1,11 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeAsyncToggle, { type AsyncToggleState, type AsyncToggleLogic } from "@duct-ui/components/button/async-toggle"
-import makeButton from "@duct-ui/components/button/button"
-import makeToggle, { type ToggleState } from "@duct-ui/components/button/toggle"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import AsyncToggle, { type AsyncToggleState, type AsyncToggleLogic } from "@duct-ui/components/button/async-toggle"
+import Button from "@duct-ui/components/button/button"
+import Toggle, { type ToggleState } from "@duct-ui/components/button/toggle"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface AsyncToggleDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -68,15 +68,6 @@ const eventLogRef = createRef<EventLogLogic>()
 const asyncToggle3Ref = createRef<any>()
 
 function render(props: BaseProps<AsyncToggleDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const AsyncToggle1 = makeAsyncToggle()
-  const AsyncToggle2 = makeAsyncToggle()
-  const AsyncToggle3 = makeAsyncToggle()
-  const AsyncToggle4 = makeAsyncToggle()
-  const RefreshBtn = makeButton()
-  const FailureModeToggle = makeToggle()
-  const DelayToggle = makeToggle()
-  const EventLog = makeEventLog()
 
   // Create separate API services for different examples
   const basicApi = new MockApiService()
@@ -151,7 +142,7 @@ function render(props: BaseProps<AsyncToggleDemoProps>) {
                 <div>
                   <h3 class="text-lg font-medium mb-2">Standard Async Toggle</h3>
                   <div class="bg-base-200 p-4 rounded-lg">
-                    <AsyncToggle1
+                    <AsyncToggle
                       data-toggle-id="basic"
                       isOn={basicApi.isOn.bind(basicApi)}
                       switchOn={basicApi.switchOn.bind(basicApi)}
@@ -169,7 +160,7 @@ function render(props: BaseProps<AsyncToggleDemoProps>) {
                 <div>
                   <h3 class="text-lg font-medium mb-2">Custom Styling</h3>
                   <div class="bg-base-200 p-4 rounded-lg">
-                    <AsyncToggle2
+                    <AsyncToggle
                       data-toggle-id="styled"
                       onLabel="🟢 Enabled"
                       offLabel="🔴 Disabled"
@@ -200,7 +191,7 @@ function render(props: BaseProps<AsyncToggleDemoProps>) {
                 <div>
                   <h3 class="text-lg font-medium mb-2">Error Handling</h3>
                   <div class="bg-base-200 p-4 rounded-lg space-y-2">
-                    <AsyncToggle3
+                    <AsyncToggle
                       ref={asyncToggle3Ref}
                       data-toggle-id="error"
                       onLabel="Success"
@@ -214,7 +205,7 @@ function render(props: BaseProps<AsyncToggleDemoProps>) {
                       on:error={handleError}
                     />
                     <div class="flex gap-2">
-                      <FailureModeToggle
+                      <Toggle
                         onLabel="Simulate Error"
                         offLabel="Simulate Success"
                         initialState="off"
@@ -233,7 +224,7 @@ function render(props: BaseProps<AsyncToggleDemoProps>) {
                 <div>
                   <h3 class="text-lg font-medium mb-2">Fast Response</h3>
                   <div class="bg-base-200 p-4 rounded-lg">
-                    <AsyncToggle4
+                    <AsyncToggle
                       data-toggle-id="fast"
                       onLabel="⚡ Fast ON"
                       offLabel="⚡ Fast OFF"
@@ -260,12 +251,12 @@ function render(props: BaseProps<AsyncToggleDemoProps>) {
               <h2 class="text-2xl font-semibold mb-4">Control Panel</h2>
               <div class="bg-base-200 p-4 rounded-lg">
                 <div class="flex gap-2 flex-wrap">
-                  <RefreshBtn
+                  <Button
                     label="Refresh All States"
                     class="btn btn-primary btn-sm"
                     on:click={handleRefresh}
                   />
-                  <DelayToggle
+                  <Toggle
                     onLabel="3s Delay"
                     offLabel="1s Delay"
                     onClass="btn btn-warning btn-sm"
@@ -327,10 +318,10 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<AsyncToggleDemoEvents
 
 const id = { id: "duct-demo/async-toggle" }
 
-export default () => {
-  return createBlueprint<AsyncToggleDemoProps, AsyncToggleDemoEvents, AsyncToggleDemoLogic>(
-    id,
-    render,
-    { bind }
-  )
-}
+const AsyncToggleDemo = createBlueprint<AsyncToggleDemoProps, AsyncToggleDemoEvents, AsyncToggleDemoLogic>(
+  id,
+  render,
+  { bind }
+)
+
+export default AsyncToggleDemo

--- a/packages/demo/src/demos/ButtonDemo.tsx
+++ b/packages/demo/src/demos/ButtonDemo.tsx
@@ -1,9 +1,9 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeButton from "@duct-ui/components/button/button"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import Button from "@duct-ui/components/button/button"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface ButtonDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -33,11 +33,7 @@ function handleButtonClick(el: Element, _e: Event) {
 
 
 function render(props: BaseProps<ButtonDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const Button1 = makeButton()
-  const Button2 = makeButton()
-  const Button3 = makeButton()
-  const EventLog = makeEventLog()
+  // All components can now be used directly without factory calls
 
 
 
@@ -51,21 +47,21 @@ function render(props: BaseProps<ButtonDemoProps>) {
         <div>
           <h2 class="text-2xl font-semibold mb-4">Three Buttons Example</h2>
           <div id="buttons" class="flex flex-row items-start gap-4">
-            <Button1
+            <Button
               label="One"
               class="btn btn-primary"
               data-message="First button clicked!"
               data-button-id="button1"
               on:click={handleButtonClick}
             />
-            <Button2
+            <Button
               label="Two"
               class="btn btn-secondary"
               data-message="Second button clicked!"
               data-button-id="button2"
               on:click={handleButtonClick}
             />
-            <Button3
+            <Button
               label="Three"
               class="btn btn-outline"
               data-message="Third button clicked!"
@@ -109,12 +105,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<ButtonDemoEvents>): B
 
 const id = { id: "duct-demo/button-demo" }
 
-export default () => {
-  return createBlueprint<ButtonDemoProps, ButtonDemoEvents, ButtonDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const ButtonDemo = createBlueprint<ButtonDemoProps, ButtonDemoEvents, ButtonDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default ButtonDemo

--- a/packages/demo/src/demos/CounterDemo.tsx
+++ b/packages/demo/src/demos/CounterDemo.tsx
@@ -1,7 +1,7 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import Dexie, { type Table } from 'dexie'
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 
 // Dexie database for persistent counter storage
 interface CounterData {
@@ -42,8 +42,6 @@ interface LoadedCounterData {
 }
 
 function render(props: BaseProps<CounterDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-
   return (
     <div {...props}>
       <DemoLayout
@@ -170,13 +168,13 @@ function bind(
 
 const id = { id: "duct-demo/counter-demo" }
 
-export default () => {
-  return createBlueprint<CounterDemoProps, CounterDemoEvents, CounterDemoLogic, LoadedCounterData>(
-    id,
-    render,
-    {
-      load,
-      bind
-    }
-  )
-}
+const CounterDemo = createBlueprint<CounterDemoProps, CounterDemoEvents, CounterDemoLogic, LoadedCounterData>(
+  id,
+  render,
+  {
+    load,
+    bind
+  }
+)
+
+export default CounterDemo

--- a/packages/demo/src/demos/DocsBuildingDemo.tsx
+++ b/packages/demo/src/demos/DocsBuildingDemo.tsx
@@ -1,5 +1,5 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 import { escapeHtml } from "../utils/htmlUtils"
 
 export interface DocsBuildingDemoEvents extends BaseComponentEvents { }
@@ -10,8 +10,6 @@ export interface DocsBuildingDemoProps {
 }
 
 function render(props: BaseProps<DocsBuildingDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-
   return (
     <div {...props}>
       <DemoLayout
@@ -100,16 +98,16 @@ function bind(el: HTMLElement, eventEmitter: EventEmitter<ButtonEvents>, props: 
   }
 }
 
-// 6. Create the blueprint
+// 6. Create and export the component directly
 const id = { id: "my-app/button" }
 
-export default function makeButton() {
-  return createBlueprint<ButtonProps, ButtonEvents, ButtonLogic>(
-    id,
-    render,
-    { bind }
-  )
-}`)}</code></pre>
+const Button = createBlueprint<ButtonProps, ButtonEvents, ButtonLogic>(
+  id,
+  render,
+  { bind }
+)
+
+export default Button`)}</code></pre>
             </div>
           </div>
 
@@ -369,33 +367,33 @@ export default function makeUserSelect() {
 
           <div class="not-prose">
             <div class="bg-base-200 rounded-lg p-6 my-4">
-              <pre class="text-sm"><code>{escapeHtml(`// Recommended: Use refs for synchronous access
+              <pre class="text-sm"><code>{escapeHtml(`// Import and use components directly
 import { createRef } from '@duct-ui/core'
+import Button from './Button' // Your component
 
 const buttonRef = createRef<ButtonLogic>()
-const Button = makeButton()
 
-function render() {
-  return <Button ref={buttonRef} label="Click me" />
+function MyApp() {
+  return (
+    <Button 
+      ref={buttonRef} 
+      label="Click me" 
+      class="btn btn-primary"
+      on:click={handleClick}
+    />
+  )
 }
 
-// Access methods immediately after component is bound
+// Access component methods via ref
 buttonRef.current?.setDisabled(true)
-buttonRef.current?.updateLabel('New Text')
-
-// Alternative: Use getLogic when you need callback timing
-// (e.g., initialization that must happen after component binding)
-Button.getLogic().then(logic => {
-  logic.setDisabled(true)
-  logic.on('click', handleClick)
-})`)}</code></pre>
+buttonRef.current?.setLabel('New Text')`)}</code></pre>
             </div>
           </div>
 
           <div class="alert alert-info my-4">
             <span class="text-sm">
-              <strong>Best Practice:</strong> Use refs for most cases as they provide synchronous access.
-              Only use getLogic when you need the callback timing for initialization or testing.
+              <strong>Direct Usage:</strong> Components can be used directly in JSX without factory functions.
+              Use refs to access component methods and state after the component is mounted.
             </span>
           </div>
 
@@ -409,6 +407,7 @@ Button.getLogic().then(logic => {
                   <ul class="text-sm space-y-2">
                     <li>✓ Use TypeScript interfaces for everything</li>
                     <li>✓ Keep render functions pure</li>
+                    <li>✓ Export components directly, not factory functions</li>
                     <li>✓ Use refs for component logic access</li>
                     <li>✓ Use data attributes for element selection</li>
                     <li>✓ Always implement the release function</li>
@@ -426,7 +425,6 @@ Button.getLogic().then(logic => {
                   <ul class="text-sm space-y-2">
                     <li>❌ Put side effects in render functions</li>
                     <li>❌ Forget to remove event listeners</li>
-                    <li>❌ Use getLogic when refs would work</li>
                     <li>❌ Use global variables for component state</li>
                     <li>❌ Query DOM elements by tag name or class</li>
                     <li>❌ Mutate props directly</li>
@@ -446,22 +444,26 @@ Button.getLogic().then(logic => {
           <div class="not-prose">
             <div class="bg-base-200 rounded-lg p-6 my-4">
               <pre class="text-sm"><code>{escapeHtml(`// Test example
-import makeButton from './Button'
+import Button from './Button'
+import { createRef } from '@duct-ui/core'
 
 describe('Button Component', () => {
   let container: HTMLElement
-  let buttonLogic: ButtonLogic
+  let buttonRef: any
 
-  beforeEach(async () => {
-    const Button = makeButton()
-
+  beforeEach(() => {
+    buttonRef = createRef()
+    
     // Render component
     container = document.createElement('div')
-    container.innerHTML = Button({ label: 'Test Button' }).toString()
     document.body.appendChild(container)
-
-    // Get component logic
-    buttonLogic = await Button.getLogic()
+    
+    // Render the button component
+    const buttonElement = Button({ 
+      ref: buttonRef,
+      label: 'Test Button' 
+    })
+    container.appendChild(buttonElement)
   })
 
   afterEach(() => {
@@ -474,23 +476,20 @@ describe('Button Component', () => {
   })
 
   test('should disable when setDisabled(true) is called', () => {
-    buttonLogic.setDisabled(true)
+    buttonRef.current?.setDisabled(true)
     const button = container.querySelector('button')
     expect(button?.disabled).toBe(true)
   })
 
-  test('should emit click event when clicked', (done) => {
+  test('should handle click events', () => {
     const button = container.querySelector('button')
-
-    // Listen for component event
-    const Button = makeButton()
-    Button.getLogic().then(logic => {
-      logic.on('click', () => {
-        done()
-      })
-    })
-
+    const clickSpy = jest.fn()
+    
+    // Set up click handler
+    button?.addEventListener('click', clickSpy)
     button?.click()
+    
+    expect(clickSpy).toHaveBeenCalled()
   })
 })`)}</code></pre>
             </div>
@@ -519,10 +518,10 @@ function bind(): BindReturn<DocsBuildingDemoLogic> {
 
 const id = { id: "duct-demo/docs-building" }
 
-export default () => {
-  return createBlueprint<DocsBuildingDemoProps, DocsBuildingDemoEvents, DocsBuildingDemoLogic>(
-    id,
-    render,
-    { bind }
-  )
-}
+const DocsBuildingDemo = createBlueprint<DocsBuildingDemoProps, DocsBuildingDemoEvents, DocsBuildingDemoLogic>(
+  id,
+  render,
+  { bind }
+)
+
+export default DocsBuildingDemo

--- a/packages/demo/src/demos/DocsClaudeCodeDemo.tsx
+++ b/packages/demo/src/demos/DocsClaudeCodeDemo.tsx
@@ -1,5 +1,5 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 import { escapeHtml } from "../utils/htmlUtils"
 
 export interface DocsClaudeCodeDemoEvents extends BaseComponentEvents { }
@@ -10,7 +10,6 @@ export interface DocsClaudeCodeDemoProps {
 }
 
 function render(props: BaseProps<DocsClaudeCodeDemoProps>) {
-  const DemoLayout = makeDemoLayout()
 
   return (
     <div {...props}>
@@ -91,8 +90,8 @@ Always reference specific Duct UI patterns and provide concrete examples from th
             <h2>The Training Process</h2>
 
             <p class="lead">
-              Claude Code can achieve 95-99% correctness when generating Duct components, but only after properly learning
-              the patterns. Here's the process to train Claude Code on your Duct codebase.
+              Claude Code can generate high-quality Duct components when it understands the patterns. 
+              Here's the process to train Claude Code on your Duct codebase.
             </p>
 
             <p>
@@ -175,7 +174,7 @@ After you've completed this review, you should understand:
 - Event handling with EventEmitter
 - DOM manipulation patterns
 - Component lifecycle management
-- How to expose component logic using refs (recommended) or getLogic callbacks
+- How to expose component logic using refs
 
 Please confirm when you've completed each step, and then I'll start asking you to help build Duct components.`}</pre>
               </div>
@@ -218,7 +217,7 @@ Please confirm when you've completed each step, and then I'll start asking you t
             <h2>Common Issues</h2>
 
             <p>
-              Even with 95-99% accuracy, you might encounter these common issues that are easy to fix:
+              Here are some common patterns to watch for when working with AI-generated Duct components:
             </p>
 
             <div>
@@ -239,18 +238,18 @@ Please confirm when you've completed each step, and then I'll start asking you t
                 </li>
                 <li>
                   <p>
-                    Claude may not remember that you can access component logic using refs (recommended) or getLogic callbacks:
+                    Claude may forget the correct component usage pattern:
                   </p>
                   <div class="not-prose">
                     <div class="bg-base-200 rounded-lg p-4 my-2">
-                      <pre class="text-sm"><code>{escapeHtml(`// Recommended: Use refs for synchronous access
-const componentRef = createRef<ComponentLogic>()
-<Component ref={componentRef} />
-componentRef.current?.method()
+                      <pre class="text-sm"><code>{escapeHtml(`// Correct: Direct component usage with refs
+import Button from '@duct-ui/components/button/button'
+import { createRef } from '@duct-ui/core'
 
-// Alternative: Use getLogic when callback timing is needed
-let logic: ComponentLogic
-Component.getLogic().then(l => logic = l)`)}</code></pre>
+const buttonRef = createRef<ButtonLogic>()
+
+<Button ref={buttonRef} label="Click me" />
+buttonRef.current?.setDisabled(true)`)}</code></pre>
                     </div>
                   </div>
                 </li>
@@ -282,10 +281,10 @@ function bind(): BindReturn<DocsClaudeCodeDemoLogic> {
 
 const id = { id: "duct-demo/docs-claude-code" }
 
-export default () => {
-  return createBlueprint<DocsClaudeCodeDemoProps, DocsClaudeCodeDemoEvents, DocsClaudeCodeDemoLogic>(
-    id,
-    render,
-    { bind }
-  )
-}
+const DocsClaudeCodeDemo = createBlueprint<DocsClaudeCodeDemoProps, DocsClaudeCodeDemoEvents, DocsClaudeCodeDemoLogic>(
+  id,
+  render,
+  { bind }
+)
+
+export default DocsClaudeCodeDemo

--- a/packages/demo/src/demos/DocsComparisonDemo.tsx
+++ b/packages/demo/src/demos/DocsComparisonDemo.tsx
@@ -1,5 +1,5 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 import { escapeHtml } from "../utils/htmlUtils"
 
 export interface DocsComparisonDemoEvents extends BaseComponentEvents { }
@@ -10,8 +10,6 @@ export interface DocsComparisonDemoProps {
 }
 
 function render(props: BaseProps<DocsComparisonDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-
   return (
     <div {...props}>
       <DemoLayout
@@ -37,6 +35,7 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <th class="font-bold">React</th>
                     <th class="font-bold">Vue</th>
                     <th class="font-bold">Svelte</th>
+                    <th class="font-bold">Web Components</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -46,12 +45,14 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <td>Component with mixed concerns</td>
                     <td>SFC with sections</td>
                     <td>Compiled components</td>
+                    <td>Custom elements with class</td>
                   </tr>
                   <tr>
                     <td class="font-medium">Virtual DOM</td>
                     <td class="text-success">❌ No</td>
                     <td class="text-warning">✅ Yes</td>
                     <td class="text-warning">✅ Yes</td>
+                    <td class="text-success">❌ No</td>
                     <td class="text-success">❌ No</td>
                   </tr>
                   <tr>
@@ -60,6 +61,7 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <td>useState/useReducer</td>
                     <td>Reactive data</td>
                     <td>Reactive stores</td>
+                    <td>Manual/Properties</td>
                   </tr>
                   <tr>
                     <td class="font-medium">Learning Curve</td>
@@ -67,6 +69,7 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <td class="text-error">Medium-High</td>
                     <td class="text-warning">Medium</td>
                     <td class="text-success">Low-Medium</td>
+                    <td class="text-warning">Medium</td>
                   </tr>
                   <tr>
                     <td class="font-medium">Template Syntax</td>
@@ -74,6 +77,7 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <td>JSX</td>
                     <td>Template/JSX</td>
                     <td>Enhanced HTML</td>
+                    <td>HTML/Template literals</td>
                   </tr>
                   <tr>
                     <td class="font-medium">Logic Location</td>
@@ -81,6 +85,7 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <td>Mixed in component</td>
                     <td>Script section</td>
                     <td>Script section</td>
+                    <td>Class methods</td>
                   </tr>
                   <tr>
                     <td class="font-medium">Reactivity</td>
@@ -88,6 +93,7 @@ function render(props: BaseProps<DocsComparisonDemoProps>) {
                     <td>Re-render based</td>
                     <td>Proxy-based</td>
                     <td>Compile-time</td>
+                    <td>Manual/Observers</td>
                   </tr>
                 </tbody>
               </table>
@@ -344,11 +350,13 @@ function bind(el, eventEmitter) {
 }
 
 // Explicit blueprint creation
-export default () => createBlueprint(
+const Button = createBlueprint(
   { id: "my/button" },
   render,
   { bind }
-);`)}</code></pre>
+);
+
+export default Button;`)}</code></pre>
                 </div>
               </div>
             </div>
@@ -383,64 +391,201 @@ export default () => createBlueprint(
             </div>
           </div>
 
-          <h2>When to Choose Each Framework</h2>
+          <h3>Duct vs Web Components</h3>
+          <p>
+            Both Duct and Web Components embrace direct DOM manipulation and standards-based approaches,
+            but they differ in their component organization and abstraction levels.
+          </p>
 
           <div class="not-prose">
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 my-6">
-              <div class="space-y-4">
-                <div class="card bg-primary/10 border border-primary/20">
-                  <div class="card-body">
-                    <h4 class="card-title text-primary">Choose Duct When</h4>
-                    <ul class="text-sm space-y-1">
-                      <li>✓ You value explicit, debuggable code</li>
-                      <li>✓ You need direct DOM control</li>
-                      <li>✓ You want minimal abstractions</li>
-                      <li>✓ You're building long-lived applications</li>
-                      <li>✓ You work with AI code generation</li>
-                      <li>✓ You prefer separation of concerns</li>
-                    </ul>
-                  </div>
-                </div>
+              <div class="card bg-base-200">
+                <div class="card-body">
+                  <h4 class="card-title text-gray-600">Web Components</h4>
+                  <pre class="text-xs overflow-x-auto"><code>{escapeHtml(`class ButtonElement extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
 
-                <div class="card bg-green-50 border border-green-200">
-                  <div class="card-body">
-                    <h4 class="card-title text-green-700">Choose Vue When</h4>
-                    <ul class="text-sm space-y-1">
-                      <li>• You want balanced complexity</li>
-                      <li>• You like single-file components</li>
-                      <li>• You need official router/state management</li>
-                      <li>• You're migrating from jQuery</li>
-                      <li>• You want good documentation</li>
-                    </ul>
-                  </div>
+  connectedCallback() {
+    this.shadowRoot.innerHTML = \`
+      <style>
+        button { padding: 8px 16px; }
+        .clicked { background: blue; }
+      </style>
+      <button>\${this.getAttribute('label')}</button>
+    \`;
+
+    this.button = this.shadowRoot.querySelector('button');
+    this.button.addEventListener('click', this.handleClick.bind(this));
+  }
+
+  handleClick() {
+    this.button.classList.add('clicked');
+    this.dispatchEvent(new CustomEvent('button-click'));
+  }
+
+  disconnectedCallback() {
+    this.button?.removeEventListener('click', this.handleClick);
+  }
+}
+
+customElements.define('my-button', ButtonElement);`)}</code></pre>
                 </div>
               </div>
 
-              <div class="space-y-4">
-                <div class="card bg-blue-50 border border-blue-200">
-                  <div class="card-body">
-                    <h4 class="card-title text-blue-700">Choose React When</h4>
-                    <ul class="text-sm space-y-1">
-                      <li>• You need the largest ecosystem</li>
-                      <li>• You have React expertise</li>
-                      <li>• You need enterprise support</li>
-                      <li>• You're building complex SPAs</li>
-                      <li>• You need extensive third-party libraries</li>
-                    </ul>
-                  </div>
-                </div>
+              <div class="card bg-primary/10 border border-primary/20">
+                <div class="card-body">
+                  <h4 class="card-title text-primary">Duct Component</h4>
+                  <pre class="text-xs overflow-x-auto"><code>{escapeHtml(`// Render function
+function render(props) {
+  return (
+    <button class="btn">
+      {props.label}
+    </button>
+  );
+}
 
-                <div class="card bg-orange-50 border border-orange-200">
-                  <div class="card-body">
-                    <h4 class="card-title text-orange-700">Choose Svelte When</h4>
-                    <ul class="text-sm space-y-1">
-                      <li>• You want the smallest bundle sizes</li>
-                      <li>• You like compile-time optimizations</li>
-                      <li>• You want built-in animations</li>
-                      <li>• You prefer simpler mental models</li>
-                      <li>• You're building content sites</li>
-                    </ul>
-                  </div>
+// Bind function
+function bind(el, eventEmitter) {
+  let clicked = false;
+
+  const handleClick = () => {
+    clicked = true;
+    el.classList.add('clicked');
+    eventEmitter.emit('click');
+  };
+
+  el.addEventListener('click', handleClick);
+
+  return { 
+    release: () => el.removeEventListener('click', handleClick) 
+  };
+}
+
+// Create component
+const Button = createBlueprint(
+  { id: "my/button" },
+  render,
+  { bind }
+);
+
+export default Button;`)}</code></pre>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="not-prose">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 my-4">
+              <div class="card bg-success/10 border border-success/20">
+                <div class="card-body">
+                  <h4 class="card-title text-success text-base">Duct Advantages</h4>
+                  <ul class="text-sm space-y-1">
+                    <li>✓ Clear separation of render/logic concerns</li>
+                    <li>✓ No Shadow DOM complexity</li>
+                    <li>✓ Simpler component composition</li>
+                    <li>✓ Framework-agnostic JSX templates</li>
+                    <li>✓ Explicit lifecycle management</li>
+                    <li>✓ Better TypeScript integration</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="card bg-warning/10 border border-warning/20">
+                <div class="card-body">
+                  <h4 class="card-title text-warning text-base">Web Components Advantages</h4>
+                  <ul class="text-sm space-y-1">
+                    <li>• Native browser standard</li>
+                    <li>• True encapsulation with Shadow DOM</li>
+                    <li>• Framework interoperability</li>
+                    <li>• No build step required</li>
+                    <li>• CSS isolation by default</li>
+                    <li>• Custom element lifecycle</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <h2>When to Choose Each Framework</h2>
+
+          <div class="not-prose">
+            {/* Duct - Full Width */}
+            <div class="card bg-primary/10 border border-primary/20 my-6">
+              <div class="card-body">
+                <h4 class="card-title text-primary text-xl">Choose Duct When</h4>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+                  <ul class="text-sm space-y-2">
+                    <li>✓ You value explicit, debuggable code</li>
+                    <li>✓ You need direct DOM control</li>
+                    <li>✓ You want minimal abstractions</li>
+                  </ul>
+                  <ul class="text-sm space-y-2">
+                    <li>✓ You're building long-lived applications</li>
+                    <li>✓ You work with AI code generation</li>
+                    <li>✓ You prefer separation of concerns</li>
+                  </ul>
+                  <ul class="text-sm space-y-2">
+                    <li>✓ You need predictable performance</li>
+                    <li>✓ You want clear debugging paths</li>
+                    <li>✓ You prioritize maintainability</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            {/* Other Frameworks - Grid */}
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 my-6">
+              <div class="card bg-green-50 border border-green-200">
+                <div class="card-body">
+                  <h4 class="card-title text-green-700">Choose Vue When</h4>
+                  <ul class="text-sm space-y-1">
+                    <li>• You want balanced complexity</li>
+                    <li>• You like single-file components</li>
+                    <li>• You need official router/state management</li>
+                    <li>• You're migrating from jQuery</li>
+                    <li>• You want good documentation</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div class="card bg-blue-50 border border-blue-200">
+                <div class="card-body">
+                  <h4 class="card-title text-blue-700">Choose React When</h4>
+                  <ul class="text-sm space-y-1">
+                    <li>• You need the largest ecosystem</li>
+                    <li>• You have React expertise</li>
+                    <li>• You need enterprise support</li>
+                    <li>• You're building complex SPAs</li>
+                    <li>• You need extensive third-party libraries</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div class="card bg-orange-50 border border-orange-200">
+                <div class="card-body">
+                  <h4 class="card-title text-orange-700">Choose Svelte When</h4>
+                  <ul class="text-sm space-y-1">
+                    <li>• You want the smallest bundle sizes</li>
+                    <li>• You like compile-time optimizations</li>
+                    <li>• You want built-in animations</li>
+                    <li>• You prefer simpler mental models</li>
+                    <li>• You're building content sites</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div class="card bg-purple-50 border border-purple-200">
+                <div class="card-body">
+                  <h4 class="card-title text-purple-700">Choose Web Components When</h4>
+                  <ul class="text-sm space-y-1">
+                    <li>• You need true framework interoperability</li>
+                    <li>• You want standards-based components</li>
+                    <li>• You need CSS encapsulation</li>
+                    <li>• You're building design systems</li>
+                    <li>• You want no build dependencies</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -469,10 +614,10 @@ function bind(): BindReturn<DocsComparisonDemoLogic> {
 
 const id = { id: "duct-demo/docs-comparison" }
 
-export default () => {
-  return createBlueprint<DocsComparisonDemoProps, DocsComparisonDemoEvents, DocsComparisonDemoLogic>(
-    id,
-    render,
-    { bind }
-  )
-}
+const DocsComparisonDemo = createBlueprint<DocsComparisonDemoProps, DocsComparisonDemoEvents, DocsComparisonDemoLogic>(
+  id,
+  render,
+  { bind }
+)
+
+export default DocsComparisonDemo

--- a/packages/demo/src/demos/DocsIntroDemo.tsx
+++ b/packages/demo/src/demos/DocsIntroDemo.tsx
@@ -1,5 +1,5 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 import { escapeHtml } from "../utils/htmlUtils"
 
 export interface DocsIntroDemoEvents extends BaseComponentEvents { }
@@ -10,7 +10,6 @@ export interface DocsIntroDemoProps {
 }
 
 function render(props: BaseProps<DocsIntroDemoProps>) {
-  const DemoLayout = makeDemoLayout()
 
   return (
     <div {...props}>
@@ -150,25 +149,19 @@ export interface ButtonEvents extends BaseComponentEvents {
 
           <h3>Component Logic Access</h3>
           <p>
-            Components expose their logic for programmatic control using refs (recommended) or getLogic callbacks:
+            Components expose their logic for programmatic control using refs:
           </p>
           <div class="not-prose">
             <div class="bg-base-200 rounded-lg p-6 my-4">
               <pre class="text-sm"><code>{escapeHtml(`// Recommended: Use refs for synchronous access
+import { Button } from '@duct-ui/components'
 const buttonRef = createRef()
-const MyButton = makeButton()
 
-<MyButton ref={buttonRef} label="Test" />
+<Button ref={buttonRef} label="Test" />
 
 // Access component logic immediately
 buttonRef.current?.setDisabled(true)
-buttonRef.current?.updateLabel('New Text')
-
-// Alternative: Use getLogic when you need callback timing
-MyButton.getLogic().then(logic => {
-  logic.setDisabled(true)
-  logic.updateLabel('New Text')
-})`)}</code></pre>
+buttonRef.current?.updateLabel('New Text')`)}</code></pre>
             </div>
           </div>
 
@@ -227,10 +220,10 @@ function bind(): BindReturn<DocsIntroDemoLogic> {
 
 const id = { id: "duct-demo/docs-intro" }
 
-export default () => {
-  return createBlueprint<DocsIntroDemoProps, DocsIntroDemoEvents, DocsIntroDemoLogic>(
-    id,
-    render,
-    { bind }
-  )
-}
+const DocsIntro = createBlueprint<DocsIntroDemoProps, DocsIntroDemoEvents, DocsIntroDemoLogic>(
+  id,
+  render,
+  { bind }
+);
+
+export default DocsIntro;

--- a/packages/demo/src/demos/DocsWhyDuctDemo.tsx
+++ b/packages/demo/src/demos/DocsWhyDuctDemo.tsx
@@ -1,5 +1,5 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 import { escapeHtml } from "../utils/htmlUtils"
 
 export interface DocsWhyDuctDemoEvents extends BaseComponentEvents { }
@@ -10,8 +10,6 @@ export interface DocsWhyDuctDemoProps {
 }
 
 function render(props: BaseProps<DocsWhyDuctDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-
   return (
     <div {...props}>
       <DemoLayout
@@ -260,10 +258,10 @@ function bind(): BindReturn<DocsWhyDuctDemoLogic> {
 
 const id = { id: "duct-demo/docs-why-duct" }
 
-export default () => {
-  return createBlueprint<DocsWhyDuctDemoProps, DocsWhyDuctDemoEvents, DocsWhyDuctDemoLogic>(
-    id,
-    render,
-    { bind }
-  )
-}
+const DocsWhyDuctDemo = createBlueprint<DocsWhyDuctDemoProps, DocsWhyDuctDemoEvents, DocsWhyDuctDemoLogic>(
+  id,
+  render,
+  { bind }
+)
+
+export default DocsWhyDuctDemo

--- a/packages/demo/src/demos/DrawerDemo.tsx
+++ b/packages/demo/src/demos/DrawerDemo.tsx
@@ -1,6 +1,6 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 
 export interface DrawerDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -16,8 +16,6 @@ export interface DrawerDemoProps {
 }
 
 function render(props: BaseProps<DrawerDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-
   return (
     <div {...props}>
       <DemoLayout
@@ -135,12 +133,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<DrawerDemoEvents>): B
 
 const id = { id: "duct-demo/drawer-demo" }
 
-export default () => {
-  return createBlueprint<DrawerDemoProps, DrawerDemoEvents, DrawerDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const DrawerDemo = createBlueprint<DrawerDemoProps, DrawerDemoEvents, DrawerDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default DrawerDemo

--- a/packages/demo/src/demos/EditableInputDemo.tsx
+++ b/packages/demo/src/demos/EditableInputDemo.tsx
@@ -1,10 +1,10 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeEditableInput from "@duct-ui/components/input/editable"
-import makeButton from "@duct-ui/components/button/button"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import EditableInput from "@duct-ui/components/input/editable"
+import Button from "@duct-ui/components/button/button"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface EditableInputDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -83,19 +83,6 @@ function getCurrentText(el: HTMLElement, e: MouseEvent) {
 }
 
 function render(props: BaseProps<EditableInputDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const EditableInput1 = makeEditableInput()
-  const EditableInput2 = makeEditableInput()
-  const EditableInput3 = makeEditableInput()
-  const EditableInput4 = makeEditableInput()
-  const SetRandomTextBtn = makeButton()
-  const ToggleEditBtn = makeButton()
-  const BeginEditBtn = makeButton()
-  const CancelEditBtn = makeButton()
-  const GetStateBtn = makeButton()
-  const EventLog = makeEventLog()
-
-
   return (
     <div {...props}>
       <DemoLayout
@@ -112,7 +99,7 @@ function render(props: BaseProps<EditableInputDemoProps>) {
             <div class="space-y-4">
               <div>
                 <h3 class="text-lg font-medium mb-2">Simple Editable Text</h3>
-                <EditableInput1
+                <EditableInput
                   text="Click me to edit!"
                   labelClass="text-lg font-medium text-primary cursor-pointer hover:bg-base-200 p-2 rounded"
                   inputClass="input input-bordered text-lg"
@@ -124,7 +111,7 @@ function render(props: BaseProps<EditableInputDemoProps>) {
 
               <div>
                 <h3 class="text-lg font-medium mb-2">Styled Editable Input</h3>
-                <EditableInput2
+                <EditableInput
                   text="Fancy styled input"
                   labelClass="badge badge-secondary badge-lg cursor-pointer hover:badge-primary transition-colors"
                   inputClass="input input-secondary input-sm"
@@ -142,7 +129,7 @@ function render(props: BaseProps<EditableInputDemoProps>) {
 
               <div>
                 <h3 class="text-lg font-medium mb-2">setText() & toggleEdit()</h3>
-                <EditableInput3
+                <EditableInput
                   ref={input3Ref}
                   text="Control me with buttons"
                   labelClass="text-base font-medium text-accent cursor-pointer hover:bg-accent/10 p-3 rounded border-2 border-accent/20"
@@ -150,13 +137,13 @@ function render(props: BaseProps<EditableInputDemoProps>) {
                   on:change={changeHandler}
                 />
                 <div class="flex gap-2 mt-3">
-                  <SetRandomTextBtn 
+                  <Button 
                     label="Set Random Text"
                     class="btn btn-sm btn-outline btn-accent"
                     data-editable-control="true"
                     on:click={setRandomText}
                   />
-                  <ToggleEditBtn 
+                  <Button 
                     label="Toggle Edit Mode"
                     class="btn btn-sm btn-outline btn-accent"
                     data-editable-control="true"
@@ -167,7 +154,7 @@ function render(props: BaseProps<EditableInputDemoProps>) {
 
               <div>
                 <h3 class="text-lg font-medium mb-2">Direct Mode Control</h3>
-                <EditableInput4
+                <EditableInput
                   ref={input4Ref}
                   text="Direct control demo"
                   labelClass="text-base font-medium text-warning cursor-pointer hover:bg-warning/10 p-3 rounded border-2 border-warning/20"
@@ -175,19 +162,19 @@ function render(props: BaseProps<EditableInputDemoProps>) {
                   on:change={changeHandler}
                 />
                 <div class="flex gap-2 mt-3">
-                  <BeginEditBtn 
+                  <Button 
                     label="Begin Edit"
                     class="btn btn-sm btn-outline btn-warning"
                     data-editable-control="true"
                     on:click={beginEdit}
                   />
-                  <CancelEditBtn 
+                  <Button 
                     label="Cancel Edit"
                     class="btn btn-sm btn-outline btn-warning"
                     data-editable-control="true"
                     on:click={cancelEdit}
                   />
-                  <GetStateBtn 
+                  <Button 
                     label="Get State"
                     class="btn btn-sm btn-outline btn-warning"
                     data-editable-control="true"
@@ -244,12 +231,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<EditableInputDemoEven
 
 const id = { id: "duct-demo/editable-input-demo" }
 
-export default () => {
-  return createBlueprint<EditableInputDemoProps, EditableInputDemoEvents, EditableInputDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const EditableInputDemo = createBlueprint<EditableInputDemoProps, EditableInputDemoEvents, EditableInputDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default EditableInputDemo

--- a/packages/demo/src/demos/EmojiListDemo.tsx
+++ b/packages/demo/src/demos/EmojiListDemo.tsx
@@ -1,13 +1,13 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeList, { type ListLogic } from "@duct-ui/components/data-display/list"
-import makeButton from "@duct-ui/components/button/button"
-import makeSelect from "@duct-ui/components/dropdown/select"
-import makeToggle, { type ToggleState } from "@duct-ui/components/button/toggle"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
-import makeEmojiItem from "../components/EmojiItem"
+import List, { type ListLogic } from "@duct-ui/components/data-display/list"
+import Button from "@duct-ui/components/button/button"
+import Select from "@duct-ui/components/dropdown/select"
+import Toggle, { type ToggleState } from "@duct-ui/components/button/toggle"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
+import EmojiItem, { type EmojiItemLogic } from "../components/EmojiItem"
 import type { SelectItem } from "@duct-ui/components/dropdown/select"
 
 export interface EmojiListDemoEvents extends BaseComponentEvents {
@@ -56,7 +56,7 @@ type EmojiKey = keyof (typeof emojiData)
 
 // Using refs instead of global variables
 const eventLogRef = createRef<EventLogLogic>()
-const emojiListRef = createRef<ListLogic<string, any>>()
+const emojiListRef = createRef<ListLogic<Record<string, any>, EmojiItemLogic>>()
 let currentCategory = "all"
 let currentPage = 0
 const pageSize = 8
@@ -190,15 +190,6 @@ async function handleToggleFavorites(_el: HTMLElement, state: ToggleState) {
 }
 
 function render(props: BaseProps<EmojiListDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const EmojiList = makeList()
-  const CategorySelect = makeSelect()
-  const PrevBtn = makeButton()
-  const NextBtn = makeButton()
-  const FavoritesToggle = makeToggle()
-  const EventLog = makeEventLog()
-
-
   // Category options
   const categories = Array.from(new Set(Object.values(emojiData).map(item => item.category)))
   const categoryOptions: SelectItem[] = [
@@ -219,7 +210,7 @@ function render(props: BaseProps<EmojiListDemoProps>) {
             <div class="flex flex-wrap gap-4 items-center p-4 bg-base-200 rounded-lg">
               <div class="flex items-center gap-2">
                 <span class="text-sm font-medium">Category:</span>
-                <CategorySelect
+                <Select
                   items={categoryOptions}
                   placeholder="Select category"
                   class="w-48"
@@ -230,7 +221,7 @@ function render(props: BaseProps<EmojiListDemoProps>) {
               </div>
 
               <div class="flex items-center gap-2">
-                <PrevBtn
+                <Button
                   label="← Previous"
                   class="btn btn-sm btn-outline"
                   on:click={handlePrevPage}
@@ -238,14 +229,14 @@ function render(props: BaseProps<EmojiListDemoProps>) {
                 <span class="text-sm px-2" id="page-label">
                   Page {currentPage + 1} of {getTotalPages()}
                 </span>
-                <NextBtn
+                <Button
                   label="Next →"
                   class="btn btn-sm btn-outline"
                   on:click={handleNextPage}
                 />
               </div>
 
-              <FavoritesToggle
+              <Toggle
                 onLabel="Show All"
                 offLabel="Show Favorites"
                 initialState={showFavoritesOnly ? 'on' : 'off'}
@@ -258,10 +249,10 @@ function render(props: BaseProps<EmojiListDemoProps>) {
 
             <div>
               <h2 class="text-xl font-semibold mb-4">Emoji Collection</h2>
-              <EmojiList
+              <List
                 ref={emojiListRef}
                 getItems={getFilteredEmojis}
-                makeItem={makeEmojiItem}
+                ItemComponent={EmojiItem}
                 itemProps={{
                   showCategory: currentCategory === "all",
                   "on:click": handleEmojiClick,
@@ -326,12 +317,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<EmojiListDemoEvents>)
 
 const id = { id: "duct-demo/emoji-list-demo" }
 
-export default () => {
-  return createBlueprint<EmojiListDemoProps, EmojiListDemoEvents, EmojiListDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const EmojiListDemo = createBlueprint<EmojiListDemoProps, EmojiListDemoEvents, EmojiListDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default EmojiListDemo

--- a/packages/demo/src/demos/IconButtonDemo.tsx
+++ b/packages/demo/src/demos/IconButtonDemo.tsx
@@ -1,9 +1,9 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeIconButton from "@duct-ui/components/button/icon-button"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import IconButton from "@duct-ui/components/button/icon-button"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 import iconOne from "../icons/one.svg"
 import iconTwo from "../icons/two.svg"
 import iconThree from "../icons/three.svg"
@@ -41,20 +41,7 @@ function handleButtonBind(el: HTMLElement) {
 }
 
 function render(props: BaseProps<IconButtonDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const IconButton1 = makeIconButton()
-  const IconButton2 = makeIconButton()
-  const IconButton3 = makeIconButton()
-  const IconButton4 = makeIconButton()
-  const IconButton5 = makeIconButton()
-  const IconButton6 = makeIconButton()
-  const EmojiButton1 = makeIconButton()
-  const EmojiButton2 = makeIconButton()
-  const EmojiButton3 = makeIconButton()
-  const EmojiButton4 = makeIconButton()
-  const EmojiButton5 = makeIconButton()
-  const EmojiButton6 = makeIconButton()
-  const EventLog = makeEventLog()
+  // All components can now be used directly without factory calls
 
 
   return (
@@ -71,7 +58,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
             <div>
               <h3 class="text-lg font-medium mb-3">Icon Positions</h3>
               <div id="buttons" class="flex flex-row items-start gap-4 tiny-button-image">
-                <IconButton1
+                <IconButton
                   icon={{ src: iconOne }}
                   position="start"
                   label="Start Icon"
@@ -80,7 +67,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                   data-button-id="icon-button1"
                   on:click={handleButtonClick}
                 />
-                <IconButton2
+                <IconButton
                   icon={{ src: iconTwo }}
                   position="end"
                   label="End Icon"
@@ -89,7 +76,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                   data-button-id="icon-button2"
                   on:click={handleButtonClick}
                 />
-                <IconButton3
+                <IconButton
                   icon={{ src: iconThree }}
                   class="btn btn-outline px-3 rounded-full"
                   data-message="Icon-only button bound!"
@@ -102,7 +89,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
             <div>
               <h3 class="text-lg font-medium mb-3">Different Styles</h3>
               <div class="flex flex-row items-start gap-4 tiny-button-image">
-                <IconButton4
+                <IconButton
                   icon={{ src: iconOne }}
                   label="Primary"
                   class="btn btn-primary"
@@ -110,7 +97,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                   data-button-id="icon-button4"
                   on:click={handleButtonClick}
                 />
-                <IconButton5
+                <IconButton
                   icon={{ src: iconTwo }}
                   label="Secondary"
                   class="btn btn-secondary"
@@ -118,7 +105,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                   data-button-id="icon-button5"
                   on:click={handleButtonClick}
                 />
-                <IconButton6
+                <IconButton
                   icon={{ src: iconThree }}
                   label="Accent"
                   class="btn btn-accent"
@@ -135,7 +122,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                 <div>
                   <h4 class="text-md font-medium mb-2 text-base-content/80">Actions</h4>
                   <div class="flex flex-row items-start gap-4">
-                    <EmojiButton1
+                    <IconButton
                       icon="❤️"
                       label="Like"
                       class="btn btn-outline"
@@ -143,7 +130,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                       data-button-id="emoji-button1"
                       on:click={handleButtonClick}
                     />
-                    <EmojiButton2
+                    <IconButton
                       icon="💾"
                       label="Save"
                       class="btn btn-outline"
@@ -151,7 +138,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                       data-button-id="emoji-button2"
                       on:click={handleButtonClick}
                     />
-                    <EmojiButton3
+                    <IconButton
                       icon="🗑️"
                       class="btn btn-outline btn-error px-3"
                       data-message="Deleted!"
@@ -164,7 +151,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                 <div>
                   <h4 class="text-md font-medium mb-2 text-base-content/80">Navigation</h4>
                   <div class="flex flex-row items-start gap-4">
-                    <EmojiButton4
+                    <IconButton
                       icon="🏠"
                       label="Home"
                       class="btn btn-primary"
@@ -172,7 +159,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                       data-button-id="emoji-button4"
                       on:click={handleButtonClick}
                     />
-                    <EmojiButton5
+                    <IconButton
                       icon="⚙️"
                       label="Settings"
                       class="btn btn-secondary"
@@ -180,7 +167,7 @@ function render(props: BaseProps<IconButtonDemoProps>) {
                       data-button-id="emoji-button5"
                       on:click={handleButtonClick}
                     />
-                    <EmojiButton6
+                    <IconButton
                       icon="📊"
                       label="Analytics"
                       class="btn btn-accent"
@@ -231,12 +218,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<IconButtonDemoEvents>
 
 const id = { id: "duct-demo/icon-button-demo" }
 
-export default () => {
-  return createBlueprint<IconButtonDemoProps, IconButtonDemoEvents, IconButtonDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const IconButtonDemo = createBlueprint<IconButtonDemoProps, IconButtonDemoEvents, IconButtonDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default IconButtonDemo

--- a/packages/demo/src/demos/MenuDemo.tsx
+++ b/packages/demo/src/demos/MenuDemo.tsx
@@ -1,12 +1,12 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeMenu from "@duct-ui/components/dropdown/menu"
-import makeMenuItem from "@duct-ui/components/dropdown/menu-item"
-import makeMenuSeparator from "@duct-ui/components/dropdown/menu-separator"
-import makeEditableInput from "@duct-ui/components/input/editable"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import Menu from "@duct-ui/components/dropdown/menu"
+import MenuItem from "@duct-ui/components/dropdown/menu-item"
+import MenuSeparator from "@duct-ui/components/dropdown/menu-separator"
+import EditableInput from "@duct-ui/components/input/editable"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface MenuDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -61,36 +61,6 @@ function editMenuItemHandler(el: HTMLElement, e: MouseEvent) {
 
 
 function render(props: BaseProps<MenuDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const Menu1 = makeMenu()
-  const Menu2 = makeMenu()
-  const Menu3 = makeMenu()
-  const Menu4 = makeMenu()
-  const Menu5 = makeMenu()
-  const Menu6 = makeMenu()
-  
-  const BasicItem1 = makeMenuItem()
-  const BasicItem2 = makeMenuItem()
-  const BasicItem3 = makeMenuItem()
-  
-  const IconItem1 = makeMenuItem()
-  const IconItem2 = makeMenuItem()
-  const IconItem3 = makeMenuItem()
-  const IconSeparator1 = makeMenuSeparator()
-  
-  const PlacementItem1 = makeMenuItem()
-  const PlacementItem2 = makeMenuItem()
-  
-  const StateItem1 = makeMenuItem()
-  const StateItem2 = makeMenuItem()
-  const StateItem3 = makeMenuItem()
-  
-  const ComposedEditableInput = makeEditableInput()
-  const ComposedMenu = makeMenu()
-  const ComposedEditMenuItem = makeMenuItem()
-  const EventLog = makeEventLog()
-
-
   return (
     <div {...props}>
       <DemoLayout
@@ -105,28 +75,28 @@ function render(props: BaseProps<MenuDemoProps>) {
           <div>
             <h2 class="text-2xl font-semibold mb-4">Basic Usage</h2>
             <div class="flex gap-4 flex-wrap">
-              <Menu1
+              <Menu
                 label="Simple Menu"
                 on:open={menuOpenHandler}
                 on:close={menuCloseHandler}
               >
-                <BasicItem1 label="First Item" on:click={itemClickHandler} />
-                <BasicItem2 label="Second Item" on:click={itemClickHandler} />
-                <BasicItem3 label="Third Item" on:click={itemClickHandler} />
-              </Menu1>
+                <MenuItem label="First Item" on:click={itemClickHandler} />
+                <MenuItem label="Second Item" on:click={itemClickHandler} />
+                <MenuItem label="Third Item" on:click={itemClickHandler} />
+              </Menu>
 
-              <Menu2
+              <Menu
                 label="Styled Menu"
                 buttonClass="btn btn-secondary"
                 menuClass="menu bg-secondary/98 rounded-box z-[1] w-52 p-2 shadow border border-primary/20"
                 on:open={menuOpenHandler}
                 on:close={menuCloseHandler}
               >
-                <IconItem1 label="Profile" icon="👤" on:click={itemClickHandler} />
-                <IconItem2 label="Settings" icon="⚙️" on:click={itemClickHandler} />
-                <IconSeparator1 />
-                <IconItem3 label="Logout" icon="🚪" on:click={itemClickHandler} />
-              </Menu2>
+                <MenuItem label="Profile" icon="👤" on:click={itemClickHandler} />
+                <MenuItem label="Settings" icon="⚙️" on:click={itemClickHandler} />
+                <MenuSeparator />
+                <MenuItem label="Logout" icon="🚪" on:click={itemClickHandler} />
+              </Menu>
             </div>
             <p class="text-sm text-base-content/60 mt-2">
               Click the buttons to see dropdown menus. Items automatically close the menu when clicked.
@@ -137,38 +107,38 @@ function render(props: BaseProps<MenuDemoProps>) {
           <div>
             <h2 class="text-2xl font-semibold mb-4">Placement Options</h2>
             <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-              <Menu3
+              <Menu
                 label="Bottom Start"
                 buttonClass="btn btn-outline btn-accent"
                 placement="bottom-start"
                 on:open={menuOpenHandler}
                 on:close={menuCloseHandler}
               >
-                <PlacementItem1 label="Item 1" on:click={itemClickHandler} />
-                <PlacementItem2 label="Item 2" on:click={itemClickHandler} />
-              </Menu3>
+                <MenuItem label="Item 1" on:click={itemClickHandler} />
+                <MenuItem label="Item 2" on:click={itemClickHandler} />
+              </Menu>
 
-              <Menu4
+              <Menu
                 label="Top Start"
                 buttonClass="btn btn-outline btn-secondary"
                 placement="top-start"
                 on:open={menuOpenHandler}
                 on:close={menuCloseHandler}
               >
-                <StateItem1 label="Item 1" on:click={itemClickHandler} />
-                <StateItem2 label="Item 2" on:click={itemClickHandler} />
-                <StateItem3 label="Disabled Item" class="text-gray-400" disabled={true} on:click={itemClickHandler} />
-              </Menu4>
+                <MenuItem label="Item 1" on:click={itemClickHandler} />
+                <MenuItem label="Item 2" on:click={itemClickHandler} />
+                <MenuItem label="Disabled Item" class="text-gray-400" disabled={true} on:click={itemClickHandler} />
+              </Menu>
 
-              <Menu5
+              <Menu
                 label="Disabled Menu"
                 buttonClass="btn btn-outline"
                 disabled={true}
                 on:open={menuOpenHandler}
                 on:close={menuCloseHandler}
               >
-                <StateItem1 label="Won't show" on:click={itemClickHandler} />
-              </Menu5>
+                <MenuItem label="Won't show" on:click={itemClickHandler} />
+              </Menu>
             </div>
             <p class="text-sm text-base-content/60 mt-2">
               Menus support different placement options and can be disabled.
@@ -186,7 +156,7 @@ function render(props: BaseProps<MenuDemoProps>) {
                 </p>
 
                 <div class="flex items-center gap-2 p-4 bg-base-200 rounded-lg">
-                  <ComposedEditableInput
+                  <EditableInput
                     ref={composedInputRef}
                     text="Click menu to edit me"
                     labelClass="text-lg font-medium text-primary cursor-pointer hover:bg-base-200 px-3 py-2 rounded border border-base-300"
@@ -194,7 +164,7 @@ function render(props: BaseProps<MenuDemoProps>) {
                     on:change={changeHandler}
                   />
 
-                  <ComposedMenu
+                  <Menu
                     label="⋮"
                     buttonClass="btn btn-sm btn-ghost"
                     menuClass="menu bg-base-200 rounded-box z-[1] w-32 p-2 shadow border border-base-300"
@@ -202,12 +172,12 @@ function render(props: BaseProps<MenuDemoProps>) {
                     on:open={menuOpenHandler}
                     on:close={menuCloseHandler}
                   >
-                    <ComposedEditMenuItem
+                    <MenuItem
                       label="Edit"
                       icon="✏️"
                       on:click={editMenuItemHandler}
                     />
-                  </ComposedMenu>
+                  </Menu>
                 </div>
 
                 <p class="text-sm text-base-content/60 mt-2">
@@ -263,12 +233,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<MenuDemoEvents>): Bin
 
 const id = { id: "duct-demo/menu-demo" }
 
-export default () => {
-  return createBlueprint<MenuDemoProps, MenuDemoEvents, MenuDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const MenuDemo = createBlueprint<MenuDemoProps, MenuDemoEvents, MenuDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default MenuDemo

--- a/packages/demo/src/demos/ModalDemo.tsx
+++ b/packages/demo/src/demos/ModalDemo.tsx
@@ -1,12 +1,12 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeModal, { ModalLogic, type ModalContentPosition } from "@duct-ui/components/layout/modal"
-import makeButton from "@duct-ui/components/button/button"
-import makeToggle from "@duct-ui/components/button/toggle"
-import makeEditable from "@duct-ui/components/input/editable"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import Modal, { ModalLogic, type ModalContentPosition } from "@duct-ui/components/layout/modal"
+import Button from "@duct-ui/components/button/button"
+import Toggle from "@duct-ui/components/button/toggle"
+import EditableInput from "@duct-ui/components/input/editable"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface ModalDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -92,8 +92,6 @@ function handleOverlayClick(_el: HTMLElement) {
 
 // Modal content components
 function createSimpleModalContent() {
-  const CloseBtn = makeButton()
-
   return (
     <div class="p-6">
       <div class="flex items-center justify-between mb-4">
@@ -113,7 +111,7 @@ function createSimpleModalContent() {
       </div>
 
       <div class="flex justify-end gap-2">
-        <CloseBtn
+        <Button
           label="Close"
           class="btn btn-primary"
           data-modal-close
@@ -124,12 +122,6 @@ function createSimpleModalContent() {
 }
 
 function createFormModalContent() {
-  const SaveBtn = makeButton()
-  const CancelBtn = makeButton()
-  const NameInput = makeEditable()
-  const EmailInput = makeEditable()
-  const NotifyToggle = makeToggle()
-
   return (
     <div class="p-6">
       <div class="flex items-center justify-between mb-4">
@@ -147,7 +139,7 @@ function createFormModalContent() {
           <label class="label">
             <span class="label-text">Full Name</span>
           </label>
-          <NameInput
+          <EditableInput
             text="John Doe"
             placeholder="Enter your name"
             labelClass="name-label"
@@ -161,7 +153,7 @@ function createFormModalContent() {
           <label class="label">
             <span class="label-text">Email Address</span>
           </label>
-          <EmailInput
+          <EditableInput
             text="john@example.com"
             placeholder="Enter your email"
             class="input input-bordered w-full"
@@ -174,7 +166,7 @@ function createFormModalContent() {
         <div class="form-control">
           <label class="label cursor-pointer">
             <span class="label-text">Email Notifications</span>
-            <NotifyToggle
+            <Toggle
               onLabel="On"
               offLabel="Off"
               initialState="on"
@@ -188,12 +180,12 @@ function createFormModalContent() {
       </form>
 
       <div class="flex justify-end gap-2">
-        <CancelBtn
+        <Button
           label="Cancel"
           class="btn btn-outline"
           data-modal-close
         />
-        <SaveBtn
+        <Button
           label="Save Changes"
           class="btn btn-primary"
           on:click={() => addToLog('Form saved successfully')}
@@ -204,9 +196,6 @@ function createFormModalContent() {
 }
 
 function createConfirmModalContent() {
-  const ConfirmBtn = makeButton()
-  const CancelBtn = makeButton()
-
   return (
     <div class="p-6">
       <div class="flex items-center mb-4">
@@ -221,12 +210,12 @@ function createConfirmModalContent() {
       </div>
 
       <div class="flex justify-end gap-2">
-        <CancelBtn
+        <Button
           label="Cancel"
           class="btn btn-outline"
           data-modal-close
         />
-        <ConfirmBtn
+        <Button
           label="Delete"
           class="btn btn-error"
           on:click={() => {
@@ -241,8 +230,6 @@ function createConfirmModalContent() {
 }
 
 function createLargeModalContent() {
-  const CloseBtn = makeButton()
-
   return (
     <div class="p-6">
       <div class="flex items-center justify-between mb-4">
@@ -275,7 +262,7 @@ function createLargeModalContent() {
       </div>
 
       <div class="flex justify-end gap-2 sticky bottom-0 bg-white pt-4 border-t">
-        <CloseBtn
+        <Button
           label="Close"
           class="btn btn-primary"
           data-modal-close
@@ -336,27 +323,6 @@ const midCenterModalRef = createRef<ModalLogic>()
 const bottomRightModalRef = createRef<ModalLogic>()
 
 function render(props: BaseProps<ModalDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const SimpleModal = makeModal()
-  const FormModal = makeModal()
-  const ConfirmModal = makeModal()
-  const LargeModal = makeModal()
-  const TopLeftModal = makeModal()
-  const MidCenterModal = makeModal()
-  const BottomRightModal = makeModal()
-  const EventLog = makeEventLog()
-
-
-  // Trigger buttons
-  const SimpleBtn = makeButton()
-  const FormBtn = makeButton()
-  const ConfirmBtn = makeButton()
-  const LargeBtn = makeButton()
-  const TopLeftBtn = makeButton()
-  const MidCenterBtn = makeButton()
-  const BottomRightBtn = makeButton()
-
-
   return (
     <div {...props}>
       <DemoLayout
@@ -370,22 +336,22 @@ function render(props: BaseProps<ModalDemoProps>) {
           <div>
             <h2 class="text-xl font-semibold mb-4">Modal Examples</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-              <SimpleBtn
+              <Button
                 label="Simple Modal"
                 class="btn btn-primary"
                 on:click={() => simpleModalRef.current?.show()}
               />
-              <FormBtn
+              <Button
                 label="Form Modal"
                 class="btn btn-secondary"
                 on:click={() => formModalRef.current?.show()}
               />
-              <ConfirmBtn
+              <Button
                 label="Confirmation"
                 class="btn btn-warning"
                 on:click={() => confirmModalRef.current?.show()}
               />
-              <LargeBtn
+              <Button
                 label="Large Modal"
                 class="btn btn-accent"
                 on:click={() => largeModalRef.current?.show()}
@@ -400,17 +366,17 @@ function render(props: BaseProps<ModalDemoProps>) {
               Demonstration of different modal positions using the contentPosition prop.
             </p>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <TopLeftBtn
+              <Button
                 label="Top Left"
                 class="btn btn-outline"
                 on:click={() => topLeftModalRef.current?.show()}
               />
-              <MidCenterBtn
+              <Button
                 label="Mid Center"
                 class="btn btn-outline"
                 on:click={() => midCenterModalRef.current?.show()}
               />
-              <BottomRightBtn
+              <Button
                 label="Bottom Right"
                 class="btn btn-outline"
                 on:click={() => bottomRightModalRef.current?.show()}
@@ -457,7 +423,7 @@ function render(props: BaseProps<ModalDemoProps>) {
           </div>
 
           {/* Modal Components */}
-          <SimpleModal
+          <Modal
             ref={simpleModalRef}
             content={createSimpleModalContent}
             data-simple-modal
@@ -466,7 +432,7 @@ function render(props: BaseProps<ModalDemoProps>) {
             on:overlayClick={handleOverlayClick}
           />
 
-          <FormModal
+          <Modal
             ref={formModalRef}
             content={createFormModalContent}
             contentClass="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-auto"
@@ -476,7 +442,7 @@ function render(props: BaseProps<ModalDemoProps>) {
             on:overlayClick={handleOverlayClick}
           />
 
-          <ConfirmModal
+          <Modal
             ref={confirmModalRef}
             content={createConfirmModalContent}
             contentClass="bg-white rounded-lg shadow-xl max-w-sm w-full mx-4"
@@ -486,7 +452,7 @@ function render(props: BaseProps<ModalDemoProps>) {
             on:overlayClick={handleOverlayClick}
           />
 
-          <LargeModal
+          <Modal
             ref={largeModalRef}
             content={createLargeModalContent}
             contentClass="max-w-4xl"
@@ -496,7 +462,7 @@ function render(props: BaseProps<ModalDemoProps>) {
             on:overlayClick={handleOverlayClick}
           />
 
-          <TopLeftModal
+          <Modal
             ref={topLeftModalRef}
             content={createTopLeftContent}
             contentPosition="top-left"
@@ -506,7 +472,7 @@ function render(props: BaseProps<ModalDemoProps>) {
             on:overlayClick={handleOverlayClick}
           />
 
-          <MidCenterModal
+          <Modal
             ref={midCenterModalRef}
             content={createMidCenterContent}
             contentPosition="mid-center"
@@ -516,7 +482,7 @@ function render(props: BaseProps<ModalDemoProps>) {
             on:overlayClick={handleOverlayClick}
           />
 
-          <BottomRightModal
+          <Modal
             ref={bottomRightModalRef}
             content={createBottomRightContent}
             contentPosition="bottom-right"
@@ -542,12 +508,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<ModalDemoEvents>): Bi
 
 const id = { id: "duct-demo/modal-demo" }
 
-export default () => {
-  return createBlueprint<ModalDemoProps, ModalDemoEvents, ModalDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const ModalDemo = createBlueprint<ModalDemoProps, ModalDemoEvents, ModalDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default ModalDemo

--- a/packages/demo/src/demos/SelectDemo.tsx
+++ b/packages/demo/src/demos/SelectDemo.tsx
@@ -1,9 +1,9 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeSelect from "@duct-ui/components/dropdown/select"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import Select from "@duct-ui/components/dropdown/select"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 import iconOne from "../icons/one.svg"
 import iconTwo from "../icons/two.svg"
 import iconThree from "../icons/three.svg"
@@ -43,13 +43,6 @@ function closeHandler(_el: HTMLElement) {
 }
 
 function render(props: BaseProps<SelectDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const Select1 = makeSelect()
-  const Select2 = makeSelect()
-  const Select3 = makeSelect()
-  const EventLog = makeEventLog()
-
-
   const basicItems: SelectItem[] = [
     { label: "Option 1", isSelected: true },
     { label: "Option 2" },
@@ -105,7 +98,7 @@ function render(props: BaseProps<SelectDemoProps>) {
             <div>
               <h3 class="text-lg font-medium mb-3">Basic Select</h3>
               <div class="max-w-sm">
-                <Select1
+                <Select
                   items={basicItems}
                   placeholder="Choose an option"
                   class="w-full dropdown relative"
@@ -126,7 +119,7 @@ function render(props: BaseProps<SelectDemoProps>) {
             <div>
               <h3 class="text-lg font-medium mb-3">Select with Icons and Descriptions</h3>
               <div class="max-w-sm">
-                <Select2
+                <Select
                   items={iconItems}
                   selectedIcon="✅"
                   placeholder="Choose with icon"
@@ -148,7 +141,7 @@ function render(props: BaseProps<SelectDemoProps>) {
             <div>
               <h3 class="text-lg font-medium mb-3">Complex Select with Attributes</h3>
               <div class="max-w-sm">
-                <Select3
+                <Select
                   items={complexItems}
                   selectedIcon="👆"
                   placeholder="Choose priority"
@@ -207,12 +200,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<SelectDemoEvents>): B
 
 const id = { id: "duct-demo/select-demo" }
 
-export default () => {
-  return createBlueprint<SelectDemoProps, SelectDemoEvents, SelectDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const SelectDemo = createBlueprint<SelectDemoProps, SelectDemoEvents, SelectDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default SelectDemo

--- a/packages/demo/src/demos/SidebarDemo.tsx
+++ b/packages/demo/src/demos/SidebarDemo.tsx
@@ -1,6 +1,6 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
-import makeDemoLayout from "../components/DemoLayout"
+import DemoLayout from "../components/DemoLayout"
 
 export interface SidebarDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -16,8 +16,6 @@ export interface SidebarDemoProps {
 }
 
 function render(props: BaseProps<SidebarDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-
   return (
     <div {...props}>
       <DemoLayout
@@ -100,12 +98,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<SidebarDemoEvents>): 
 
 const id = { id: "duct-demo/sidebar-demo" }
 
-export default () => {
-  return createBlueprint<SidebarDemoProps, SidebarDemoEvents, SidebarDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const SidebarDemo = createBlueprint<SidebarDemoProps, SidebarDemoEvents, SidebarDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default SidebarDemo

--- a/packages/demo/src/demos/TabsDemo.tsx
+++ b/packages/demo/src/demos/TabsDemo.tsx
@@ -1,12 +1,12 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeTabs, { type TabItem } from "@duct-ui/components/layout/tabs"
-import makeButton from "@duct-ui/components/button/button"
-import makeToggle from "@duct-ui/components/button/toggle"
-import makeEditable from "@duct-ui/components/input/editable"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import Tabs, { type TabItem } from "@duct-ui/components/layout/tabs"
+import Button from "@duct-ui/components/button/button"
+import Toggle from "@duct-ui/components/button/toggle"
+import EditableInput from "@duct-ui/components/input/editable"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface TabsDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -36,7 +36,6 @@ function handleTabChange(_el: HTMLElement, activeTabId: string) {
 
 // Sample tab content components
 function createOverviewContent() {
-  const Button1 = makeButton()
   return (
     <div class="p-4 space-y-4">
       <h3 class="text-lg font-semibold">Welcome to the Dashboard</h3>
@@ -56,7 +55,7 @@ function createOverviewContent() {
         </div>
       </div>
       <div class="mt-4">
-        <Button1
+        <Button
           label="View Details"
           class="btn btn-primary"
           on:click={() => addToLog('Overview details button clicked')}
@@ -67,12 +66,11 @@ function createOverviewContent() {
 }
 
 function createAnalyticsContent() {
-  const RefreshBtn = makeButton()
   return (
     <div class="p-4 space-y-4">
       <div class="flex items-center justify-between">
         <h3 class="text-lg font-semibold">Analytics Dashboard</h3>
-        <RefreshBtn
+        <Button
           label="Refresh Data"
           class="btn btn-sm btn-outline"
           on:click={() => addToLog('Analytics data refreshed')}
@@ -105,9 +103,6 @@ function createAnalyticsContent() {
 }
 
 function createSettingsContent() {
-  // Create nested tabs for settings
-  const SettingsTabs = makeTabs()
-  
   const settingsTabItems: TabItem[] = [
     {
       id: 'general',
@@ -134,7 +129,7 @@ function createSettingsContent() {
   return (
     <div class="p-4 space-y-4">
       <h3 class="text-lg font-semibold">Settings</h3>
-      <SettingsTabs
+      <Tabs
         items={settingsTabItems}
         activeTabId="general"
         tabClass="tab tab-sm"
@@ -147,17 +142,13 @@ function createSettingsContent() {
 }
 
 function createGeneralSettingsContent() {
-  const SaveBtn = makeButton()
-  const NotificationsToggle = makeToggle()
-  const UsernameInput = makeEditable()
-
   return (
     <div class="space-y-6">
       <div class="form-control">
         <label class="label">
           <span class="label-text">Username</span>
         </label>
-        <UsernameInput
+        <EditableInput
           text="john_doe"
           labelClass="user-name-label"
           inputClass="user-name-input"
@@ -170,7 +161,7 @@ function createGeneralSettingsContent() {
       <div class="form-control">
         <label class="label cursor-pointer">
           <span class="label-text">Email Notifications</span>
-          <NotificationsToggle
+          <Toggle
             onLabel="Enabled"
             offLabel="Disabled"
             initialState="on"
@@ -185,12 +176,12 @@ function createGeneralSettingsContent() {
       <div class="divider"></div>
 
       <div class="flex gap-2">
-        <SaveBtn
+        <Button
           label="Save Changes"
           class="btn btn-primary"
           on:click={() => addToLog('General settings saved')}
         />
-        <SaveBtn
+        <Button
           label="Reset"
           class="btn btn-outline"
           on:click={() => addToLog('General settings reset')}
@@ -201,10 +192,6 @@ function createGeneralSettingsContent() {
 }
 
 function createProfileSettingsContent() {
-  const NameInput = makeEditable()
-  const BioInput = makeEditable()
-  const SaveBtn = makeButton()
-  
   return (
     <div class="space-y-4">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -212,7 +199,7 @@ function createProfileSettingsContent() {
           <label class="label">
             <span class="label-text">Display Name</span>
           </label>
-          <NameInput
+          <EditableInput
             text="John Doe"
             labelClass="display-name-label"
             inputClass="display-name-input"
@@ -225,7 +212,7 @@ function createProfileSettingsContent() {
           <label class="label">
             <span class="label-text">Bio</span>
           </label>
-          <BioInput
+          <EditableInput
             text="Software developer"
             labelClass="bio-label"
             inputClass="bio-input"
@@ -235,7 +222,7 @@ function createProfileSettingsContent() {
           />
         </div>
       </div>
-      <SaveBtn
+      <Button
         label="Update Profile"
         class="btn btn-primary"
         on:click={() => addToLog('Profile settings saved')}
@@ -245,9 +232,6 @@ function createProfileSettingsContent() {
 }
 
 function createSecuritySettingsContent() {
-  const ChangePasswordBtn = makeButton()
-  const TwoFactorToggle = makeToggle()
-  
   return (
     <div class="space-y-4">
       <div class="alert alert-warning">
@@ -260,7 +244,7 @@ function createSecuritySettingsContent() {
       <div class="form-control">
         <label class="label cursor-pointer">
           <span class="label-text">Two-Factor Authentication</span>
-          <TwoFactorToggle
+          <Toggle
             onLabel="Enabled"
             offLabel="Disabled"
             initialState="off"
@@ -272,7 +256,7 @@ function createSecuritySettingsContent() {
         </label>
       </div>
       
-      <ChangePasswordBtn
+      <Button
         label="Change Password"
         class="btn btn-warning"
         on:click={() => addToLog('Password change initiated')}
@@ -282,16 +266,12 @@ function createSecuritySettingsContent() {
 }
 
 function createPrivacySettingsContent() {
-  const PublicProfileToggle = makeToggle()
-  const DataSharingToggle = makeToggle()
-  const SaveBtn = makeButton()
-  
   return (
     <div class="space-y-4">
       <div class="form-control">
         <label class="label cursor-pointer">
           <span class="label-text">Public Profile</span>
-          <PublicProfileToggle
+          <Toggle
             onLabel="Public"
             offLabel="Private"
             initialState="on"
@@ -306,7 +286,7 @@ function createPrivacySettingsContent() {
       <div class="form-control">
         <label class="label cursor-pointer">
           <span class="label-text">Data Sharing</span>
-          <DataSharingToggle
+          <Toggle
             onLabel="Allowed"
             offLabel="Blocked"
             initialState="off"
@@ -320,7 +300,7 @@ function createPrivacySettingsContent() {
       
       <div class="divider"></div>
       
-      <SaveBtn
+      <Button
         label="Save Privacy Settings"
         class="btn btn-primary"
         on:click={() => addToLog('Privacy settings saved')}
@@ -331,11 +311,6 @@ function createPrivacySettingsContent() {
 
 
 function render(props: BaseProps<TabsDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const MainTabs = makeTabs()
-  const EventLog = makeEventLog()
-
-
   // Main dashboard tabs
   const mainTabItems: TabItem[] = [
     {
@@ -373,7 +348,7 @@ function render(props: BaseProps<TabsDemoProps>) {
           {/* Main Tabs Example */}
           <div>
             <h2 class="text-xl font-semibold mb-4">Dashboard with Nested Tabs</h2>
-            <MainTabs
+            <Tabs
               items={mainTabItems}
               activeTabId="overview"
               tabClass="tab"
@@ -436,12 +411,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<TabsDemoEvents>): Bin
 
 const id = { id: "duct-demo/tabs-demo" }
 
-export default () => {
-  return createBlueprint<TabsDemoProps, TabsDemoEvents, TabsDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const TabsDemo = createBlueprint<TabsDemoProps, TabsDemoEvents, TabsDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default TabsDemo

--- a/packages/demo/src/demos/ToggleDemo.tsx
+++ b/packages/demo/src/demos/ToggleDemo.tsx
@@ -1,9 +1,9 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeToggle, { type ToggleState } from "@duct-ui/components/button/toggle"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import Toggle, { type ToggleState } from "@duct-ui/components/button/toggle"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 
 export interface ToggleDemoEvents extends BaseComponentEvents {
   // No custom events needed for this demo
@@ -44,14 +44,6 @@ function handlePremiumToggle(_el: HTMLElement, state: ToggleState) {
 }
 
 function render(props: BaseProps<ToggleDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const LightToggle = makeToggle()
-  const NotificationsToggle = makeToggle()
-  const ModeToggle = makeToggle()
-  const PremiumToggle = makeToggle()
-  const EventLog = makeEventLog()
-
-
   return (
     <div {...props}>
       <DemoLayout
@@ -71,7 +63,7 @@ function render(props: BaseProps<ToggleDemoProps>) {
                     <div class="font-medium">Room Light</div>
                     <div class="text-sm text-base-content/60">Control room lighting</div>
                   </div>
-                  <LightToggle
+                  <Toggle
                     onLabel="Turn Off"
                     offLabel="Turn On"
                     initialState="off"
@@ -87,7 +79,7 @@ function render(props: BaseProps<ToggleDemoProps>) {
                     <div class="font-medium">Notifications</div>
                     <div class="text-sm text-base-content/60">Enable push notifications</div>
                   </div>
-                  <NotificationsToggle
+                  <Toggle
                     onLabel="Disable"
                     offLabel="Enable"
                     initialState="on"
@@ -109,7 +101,7 @@ function render(props: BaseProps<ToggleDemoProps>) {
                     <div class="font-medium">Theme Mode</div>
                     <div class="text-sm text-base-content/60">Switch between light and dark</div>
                   </div>
-                  <ModeToggle
+                  <Toggle
                     onLabel="🌙 Dark"
                     offLabel="☀️ Light"
                     initialState="off"
@@ -125,7 +117,7 @@ function render(props: BaseProps<ToggleDemoProps>) {
                     <div class="font-medium">Premium Features</div>
                     <div class="text-sm text-base-content/60">Access premium functionality</div>
                   </div>
-                  <PremiumToggle
+                  <Toggle
                     onLabel="⭐ Active"
                     offLabel="Upgrade"
                     initialState="off"
@@ -191,12 +183,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<ToggleDemoEvents>): B
 
 const id = { id: "duct-demo/toggle-demo" }
 
-export default () => {
-  return createBlueprint<ToggleDemoProps, ToggleDemoEvents, ToggleDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const ToggleDemo = createBlueprint<ToggleDemoProps, ToggleDemoEvents, ToggleDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default ToggleDemo

--- a/packages/demo/src/demos/TreeViewDemo.tsx
+++ b/packages/demo/src/demos/TreeViewDemo.tsx
@@ -1,10 +1,10 @@
 import { createBlueprint, type BindReturn, type BaseComponentEvents, type BaseProps } from "@duct-ui/core/blueprint"
 import { EventEmitter } from "@duct-ui/core/shared"
 import { createRef } from "@duct-ui/core"
-import makeTreeView from "@duct-ui/components/data-display/tree-view"
-import makeButton from "@duct-ui/components/button/button"
-import makeDemoLayout from "../components/DemoLayout"
-import makeEventLog, { EventLogLogic } from "../components/EventLog"
+import TreeView from "@duct-ui/components/data-display/tree-view"
+import Button from "@duct-ui/components/button/button"
+import DemoLayout from "../components/DemoLayout"
+import EventLog, { EventLogLogic } from "../components/EventLog"
 import { TreeViewData, TreePath } from "@duct-ui/components/data-display/structure"
 import "@duct-ui/components/data-display/tree-view.css"
 
@@ -384,19 +384,6 @@ function loadProject2(el: HTMLElement, e: MouseEvent) {
 }
 
 function render(props: BaseProps<TreeViewDemoProps>) {
-  const DemoLayout = makeDemoLayout()
-  const TreeView1 = makeTreeView()
-  const TreeView2 = makeTreeView()
-  const TreeView3 = makeTreeView()
-  const ExpandAllBtn = makeButton()
-  const CollapseAllBtn = makeButton()
-  const ExpandSrcBtn = makeButton()
-  const CollapseSrcBtn = makeButton()
-  const LoadProject1Btn = makeButton()
-  const LoadProject2Btn = makeButton()
-  const EventLog = makeEventLog()
-
-
   return (
     <div {...props}>
       <DemoLayout
@@ -415,7 +402,7 @@ function render(props: BaseProps<TreeViewDemoProps>) {
                 <div>
                   <h3 class="text-lg font-medium mb-2">Simple Tree</h3>
                   <div class="bg-base-200 p-4 rounded-lg">
-                    <TreeView1
+                    <TreeView
                       data={simpleTree}
                       initialExpanded={[["animals"]]}
                       labelClass="cursor-pointer hover:bg-base-300 px-2 py-1 rounded transition-colors"
@@ -433,7 +420,7 @@ function render(props: BaseProps<TreeViewDemoProps>) {
                 <div>
                   <h3 class="text-lg font-medium mb-2">Icon-Only Expand</h3>
                   <div class="bg-base-200 p-4 rounded-lg">
-                    <TreeView2
+                    <TreeView
                       data={simpleTree}
                       expandOnLabelClick={false}
                       class="text-lg"
@@ -459,12 +446,12 @@ function render(props: BaseProps<TreeViewDemoProps>) {
 
                 <div class="flex gap-2 mb-4 flex-wrap">
                   <div class="flex gap-2">
-                    <LoadProject1Btn
+                    <Button
                       label="Load Project 1"
                       class="btn btn-sm btn-success"
                       on:click={loadProject1}
                     />
-                    <LoadProject2Btn
+                    <Button
                       label="Load Project 2"
                       class="btn btn-sm btn-info"
                       on:click={loadProject2}
@@ -472,22 +459,22 @@ function render(props: BaseProps<TreeViewDemoProps>) {
                   </div>
 
                   <div class="flex gap-2">
-                    <ExpandAllBtn
+                    <Button
                       label="Expand All"
                       class="btn btn-sm btn-primary"
                       on:click={expandAll}
                     />
-                    <CollapseAllBtn
+                    <Button
                       label="Collapse All"
                       class="btn btn-sm btn-secondary"
                       on:click={collapseAll}
                     />
-                    <ExpandSrcBtn
+                    <Button
                       label="Expand src/"
                       class="btn btn-sm btn-accent"
                       on:click={expandSrc}
                     />
-                    <CollapseSrcBtn
+                    <Button
                       label="Collapse src/"
                       class="btn btn-sm btn-warning"
                       on:click={collapseSrc}
@@ -496,7 +483,7 @@ function render(props: BaseProps<TreeViewDemoProps>) {
                 </div>
 
                 <div class="bg-base-200 p-4 rounded-lg">
-                  <TreeView3
+                  <TreeView
                     ref={treeView3Ref}
                     data={project1FileSystem}
                     initialExpanded={[["src"], ["docs"]]}
@@ -563,12 +550,12 @@ function bind(el: HTMLElement, _eventEmitter: EventEmitter<TreeViewDemoEvents>):
 
 const id = { id: "duct-demo/tree-view-demo" }
 
-export default () => {
-  return createBlueprint<TreeViewDemoProps, TreeViewDemoEvents, TreeViewDemoLogic>(
-    id,
-    render,
-    {
-      bind
-    }
-  )
-}
+const TreeViewDemo = createBlueprint<TreeViewDemoProps, TreeViewDemoEvents, TreeViewDemoLogic>(
+  id,
+  render,
+  {
+    bind
+  }
+)
+
+export default TreeViewDemo

--- a/packages/demo/src/demos/index.ts
+++ b/packages/demo/src/demos/index.ts
@@ -1,22 +1,22 @@
-import makeButtonDemo from "./ButtonDemo"
-import makeIconButtonDemo from "./IconButtonDemo"
-import makeToggleDemo from "./ToggleDemo"
-import makeAsyncToggleDemo from "./AsyncToggleDemo"
-import makeEditableInputDemo from "./EditableInputDemo"
-import makeMenuDemo from "./MenuDemo"
-import makeSelectDemo from "./SelectDemo"
-import makeTreeViewDemo from "./TreeViewDemo"
-import makeSidebarDemo from "./SidebarDemo"
-import makeDrawerDemo from "./DrawerDemo"
-import makeTabsDemo from "./TabsDemo"
-import makeModalDemo from "./ModalDemo"
-import makeEmojiListDemo from "./EmojiListDemo"
-import makeCounterDemo from "./CounterDemo"
-import makeDocsIntroDemo from "./DocsIntroDemo"
-import makeDocsWhyDuctDemo from "./DocsWhyDuctDemo"
-import makeDocsComparisonDemo from "./DocsComparisonDemo"
-import makeDocsBuildingDemo from "./DocsBuildingDemo"
-import makeDocsClaudeCodeDemo from "./DocsClaudeCodeDemo"
+import ButtonDemo from "./ButtonDemo"
+import IconButtonDemo from "./IconButtonDemo"
+import ToggleDemo from "./ToggleDemo"
+import AsyncToggleDemo from "./AsyncToggleDemo"
+import EditableInputDemo from "./EditableInputDemo"
+import MenuDemo from "./MenuDemo"
+import SelectDemo from "./SelectDemo"
+import TreeViewDemo from "./TreeViewDemo"
+import SidebarDemo from "./SidebarDemo"
+import DrawerDemo from "./DrawerDemo"
+import TabsDemo from "./TabsDemo"
+import ModalDemo from "./ModalDemo"
+import EmojiListDemo from "./EmojiListDemo"
+import CounterDemo from "./CounterDemo"
+import DocsIntroDemo from "./DocsIntroDemo"
+import DocsWhyDuctDemo from "./DocsWhyDuctDemo"
+import DocsComparisonDemo from "./DocsComparisonDemo"
+import DocsBuildingDemo from "./DocsBuildingDemo"
+import DocsClaudeCodeDemo from "./DocsClaudeCodeDemo"
 
 export interface DemoInfo {
   id: string
@@ -41,7 +41,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "What is Duct?",
         description: "Introduction to the Duct UI Framework and its core concepts",
         component: () => {
-          const DocsIntroDemo = makeDocsIntroDemo()
           return DocsIntroDemo({})
         }
       },
@@ -50,7 +49,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Why Choose Duct?",
         description: "Benefits and advantages of using the Duct UI Framework",
         component: () => {
-          const DocsWhyDuctDemo = makeDocsWhyDuctDemo()
           return DocsWhyDuctDemo({})
         }
       },
@@ -59,7 +57,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Duct vs Other Frameworks",
         description: "How Duct compares to React, Vue, and Svelte",
         component: () => {
-          const DocsComparisonDemo = makeDocsComparisonDemo()
           return DocsComparisonDemo({})
         }
       },
@@ -68,7 +65,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Building Components",
         description: "A comprehensive guide to creating Duct components",
         component: () => {
-          const DocsBuildingDemo = makeDocsBuildingDemo()
           return DocsBuildingDemo({})
         }
       },
@@ -77,7 +73,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Using Claude Code",
         description: "How to train Claude Code to generate high-quality Duct components",
         component: () => {
-          const DocsClaudeCodeDemo = makeDocsClaudeCodeDemo()
           return DocsClaudeCodeDemo({})
         }
       }
@@ -96,7 +91,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Basic Button",
         description: "Basic button component with event handling",
         component: () => {
-          const ButtonDemo = makeButtonDemo()
           return ButtonDemo({})
         }
       },
@@ -105,7 +99,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Icon Button",
         description: "Button component with icon support",
         component: () => {
-          const IconButtonDemo = makeIconButtonDemo()
           return IconButtonDemo({})
         }
       },
@@ -114,7 +107,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Toggle Button",
         description: "Toggle button with on/off states and custom styling",
         component: () => {
-          const ToggleDemo = makeToggleDemo()
           return ToggleDemo({})
         }
       },
@@ -123,7 +115,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Async Toggle",
         description: "Asynchronous toggle button with custom async operations and loading states",
         component: () => {
-          const AsyncToggleDemo = makeAsyncToggleDemo()
           return AsyncToggleDemo({})
         }
       }
@@ -138,7 +129,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Editable Input",
         description: "Click-to-edit input with keyboard shortcuts",
         component: () => {
-          const EditableInputDemo = makeEditableInputDemo()
           return EditableInputDemo({})
         }
       }
@@ -153,7 +143,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Menu & MenuItem",
         description: "Dropdown menus with customizable placement and actions",
         component: () => {
-          const MenuDemo = makeMenuDemo()
           return MenuDemo({})
         }
       },
@@ -162,7 +151,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Select",
         description: "Dropdown select component with selection markers",
         component: () => {
-          const SelectDemo = makeSelectDemo()
           return SelectDemo({})
         }
       }
@@ -177,7 +165,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "TreeView",
         description: "Collapsible tree view for hierarchical data",
         component: () => {
-          const TreeViewDemo = makeTreeViewDemo()
           return TreeViewDemo({})
         }
       },
@@ -186,7 +173,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "List",
         description: "Interactive list with filtering, pagination, and component logic access",
         component: () => {
-          const EmojiListDemo = makeEmojiListDemo()
           return EmojiListDemo({})
         }
       }
@@ -201,7 +187,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Tabs",
         description: "Tabbed interface with dynamic content and nested tabs",
         component: () => {
-          const TabsDemo = makeTabsDemo()
           return TabsDemo({})
         }
       },
@@ -210,7 +195,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Modal Window",
         description: "Modal dialogs with customizable overlays and content",
         component: () => {
-          const ModalDemo = makeModalDemo()
           return ModalDemo({})
         }
       },
@@ -219,7 +203,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Sidebar Navigation",
         description: "Navigation sidebar with sections and hierarchical items",
         component: () => {
-          const SidebarDemo = makeSidebarDemo()
           return SidebarDemo({})
         }
       },
@@ -228,7 +211,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Drawer",
         description: "Responsive drawer component for mobile and desktop layouts",
         component: () => {
-          const DrawerDemo = makeDrawerDemo()
           return DrawerDemo({})
         }
       }
@@ -243,7 +225,6 @@ export const demoCategories: (DemoCategory | { type: 'separator', title?: string
         title: "Async Counter",
         description: "Counter component demonstrating async data loading with IndexedDB persistence",
         component: () => {
-          const CounterDemo = makeCounterDemo()
           return CounterDemo({})
         }
       }

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -5,7 +5,8 @@ import { resolve } from "path"
 export default defineConfig({
   root: ".",
   server: {
-    port: 3333
+    port: 3333,
+    historyApiFallback: true
   },
   build: {
     emptyOutDir: true,


### PR DESCRIPTION
- Ensure that you can use the imported default component directly
- Remove getLogic in favor of refs
- Update all demos & documentation
- Use regular urls for demo navigation